### PR TITLE
duo(1): support out.js, closes #24

### DIFF
--- a/bin/_duo
+++ b/bin/_duo
@@ -4,13 +4,16 @@
  * Module dependencies.
  */
 
+var write = require('fs').createWriteStream;
 var Command = require('commander').Command;
 var resolve = require('path').resolve;
 var exists = require('fs').existsSync;
+var mkdirp = require('mkdirp').sync;
 var Logger = require('stream-log');
 var stat = require('fs').statSync;
 var spawn = require('win-fork');
 var pkg = require('../package');
+var path = require('path');
 var fs = require('co-fs');
 var Duo = require('..');
 var co = require('co');
@@ -90,10 +93,19 @@ if (!command) program.help();
  */
 
 if (~command.indexOf('.')) {
-  var duo = Duo(process.cwd());
+  var root = process.cwd();
+  var duo = Duo(root);
+  var out = process.stdout;
   duo.entry(command);
   duo.run = co(duo.run);
   duo.development(program.development);
+
+  // out
+  if (program.args[1]) {
+    var file = path.join(root, program.args[1]);
+    mkdirp(path.dirname(file));
+    out = write(file);
+  }
 
   // events
   duo.on('resolving', log('finding'));
@@ -104,8 +116,9 @@ if (~command.indexOf('.')) {
   return duo.run(function(err, str){
     if (err) logger.error(err);
     logger.end();
-    console.log(str);
-    process.exit(0);
+    out.write(str, function(){
+      process.exit(0);
+    });
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "extend.js": "0.0.1",
     "file-deps": "0.0.2",
     "max-component": "~1.0.0",
+    "mkdirp": "^0.5.0",
     "stream-log": "0.1.0",
     "thunkify": "~2.1.1",
     "v8-argv": "^0.2.0",


### PR DESCRIPTION
we can also separate `duo(1)` to `duo-build(1)` and `duo-install(1)`, but didn't do so because ATM duo doesn't differentiate between the two.

long term i think we should just have an installer/parser and the builder, then we can separate stuff.

cc @MatthewMueller 
