### PR TITLE
perf: dont visit files more than once

### DIFF
--- a/lib/duo.js
+++ b/lib/duo.js
@@ -261,6 +261,13 @@ Duo.prototype.dependencies = function *(file, root, out) {
 
   var json = this.json(join(root, this.manifestName));
   var relativeFile = relative(this.root, file);
+
+  // visited.
+  if (out[relativeFile]) {
+    debug('ignoring %s, already parsed', relativeFile);
+    return out;
+  }
+
   var mapping = this.mapping[relativeFile];
   var layer = out[relativeFile] = { deps: {} };
   var mtime = layer.mtime = (yield fs.stat(file)).mtime.getTime();

--- a/test/duo.js
+++ b/test/duo.js
@@ -26,7 +26,7 @@ describe('Duo', function(){
     assert.deepEqual('resolved', ctx.main);
   });
 
-  it.only('should resolve relative files like `require(../path/file.js`', function*(){
+  it('should resolve relative files like `require(../path/file.js`', function*(){
     var js = yield build('resolve-file').run();
     var ctx = evaluate(js);
     assert('resolved' == ctx.main);


### PR DESCRIPTION
before:
![screen shot 2014-06-09 at 7 51 54 pm](https://cloud.githubusercontent.com/assets/1661587/3219574/0c836822-eff7-11e3-81fb-7665cb00128b.png)

after:
![screen shot 2014-06-09 at 7 52 54 pm](https://cloud.githubusercontent.com/assets/1661587/3219575/11077032-eff7-11e3-8c63-e70faf21fdf2.png)

didn't use any local cache for both cases, with cache there are some gains too.
