### PR TITLE
support duo.entry('index.coffee'). fix duo.use(fn*)

### DIFF
--- a/lib/duo.js
+++ b/lib/duo.js
@@ -32,6 +32,12 @@ var slice = [].slice;
 module.exports = Duo;
 
 /**
+ * Regexps
+ */
+
+var rsupported = /^(js|css|html)$/;
+
+/**
  * Initialize `Duo`
  *
  * @param {String} root
@@ -262,6 +268,7 @@ Duo.prototype.dependencies = function *(file, root, out) {
 
   var json = this.json(join(root, this.manifestName));
   var relativeFile = relative(this.root, file);
+  var isEntry = file == this._entry;
 
   // visited.
   if (out[relativeFile]) {
@@ -301,6 +308,15 @@ Duo.prototype.dependencies = function *(file, root, out) {
 
   // 3) File contents are transformed
   yield this.transform(layer);
+
+  // Update root extension here, because we might pass
+  // in a .coffee or .styl file as the entry
+  if (isEntry) {
+    this.rootext = layer.type;
+    if (!rsupported.test(layer.type)) {
+      throw error('%s file type not supported.', layer.type);
+    }
+  }
 
   // 4) Parse content for dependencies
   var deps = filedeps(layer.src, layer.type);
@@ -607,5 +623,5 @@ function entry(json){
  */
 
 function generator(value){
-  return value && 'GeneratorFunction' == ({}).toString.call(value);
+  return value && value.constructor && 'GeneratorFunction' == value.constructor.name;
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "mocha": "^1.20.1",
     "rimraf": "^2.2.8",
     "expect.js": "^0.3.1",
-    "styl": "^0.2.7"
+    "styl": "^0.2.7",
+    "coffee-script": "~1.7.1"
   },
   "bin": {
     "duo": "bin/duo",

--- a/test/fixtures/coffee-deps/index.js
+++ b/test/fixtures/coffee-deps/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./one.coffee');

--- a/test/fixtures/coffee-deps/one.coffee
+++ b/test/fixtures/coffee-deps/one.coffee
@@ -1,0 +1,4 @@
+module.exports =
+  a: 'a'
+  b: 'b'
+  c: 'c'

--- a/test/fixtures/coffee/index.coffee
+++ b/test/fixtures/coffee/index.coffee
@@ -1,0 +1,4 @@
+module.exports =
+  a: 'a'
+  b: 'b'
+  c: 'c'


### PR DESCRIPTION
- allow entries to be .coffee, .styl

Update the `rootext` after the transforms on entry files
- fix generator plugins

Use co's `isGenerator function`
