### PR TITLE
pack: sort names before packing, fixes #49

### DIFF
--- a/lib/duo.js
+++ b/lib/duo.js
@@ -214,6 +214,7 @@ Duo.prototype.run = function *() {
 
   // build
   var names = Object.keys(deps);
+  deps[names[0]].entry = true;
 
   // not js
   // TODO: change filedeps to remove
@@ -224,18 +225,18 @@ Duo.prototype.run = function *() {
     }).join('');
   }
 
-  // gens
-  var gens = names.map(function*(name, i){
-    var last = i == names.length - 1;
-    var dep = deps[name];
-    var entry = dep.entry = 0 == i;
-    dep.id = name;
-    dep.global = entry && global;
-    return yield pack(dep, last);
-  });
-
   // pack
-  return (yield this.parallel(gens)).join('');
+  names.sort();
+  var js = '';
+  for (var i = 0, name; name = names[i++];) {
+    var dep = deps[name];
+    var last = i == names.length;
+    dep.id = name;
+    dep.global = dep.entry && global;
+    js += yield pack(dep, last);
+  }
+
+  return js;
 };
 
 /**


### PR DESCRIPTION
really hard to add a test case for this one, i managed to test this out manually `entry` example since it uses analytics.js

basically just sorts the names to make sure the order is correct in the file to ensure it's the same even if you `rm -rf components` and reinstall.

cc @MatthewMueller 
