### PR TITLE
expose entry key in duo.json

### DIFF
--- a/lib/duo.js
+++ b/lib/duo.js
@@ -246,7 +246,6 @@ Duo.prototype.run = function *() {
 
   // build
   var names = Object.keys(deps);
-  deps[names[0]].entry = true;
 
   // not js
   // TODO: change filedeps to remove
@@ -339,6 +338,9 @@ Duo.prototype.dependencies = function *(file, root, out) {
     yield gens;
     return out;
   }
+
+  // entry
+  if (isEntry) layer.entry = true;
 
   // id, path, type
   layer.id = relativeFile;


### PR DESCRIPTION
This is useful for plugins that want to use the `duo.json` mapping.
