### PR TITLE
fix/edge-case-extensions

### DIFF
--- a/lib/duo.js
+++ b/lib/duo.js
@@ -549,7 +549,6 @@ Duo.prototype.package = function(dep, json) {
  * @param {Object} gh
  * @param {Object} json
  * @return {Object}
- *
  * @api private
  */
 
@@ -560,7 +559,7 @@ Duo.prototype.finddeps = function(gh, json) {
   }
 
   var deps = json.dependencies || {};
-  var rext = '([\.\-][a-z]+)?';
+  var rext = '([\.][a-z]+)?';
 
   if (this.dev && json == this.rootjson) {
     deps = extend(deps, json.development || {});


### PR DESCRIPTION
that's an edge case when you have, you can repro this by cloning segmentio-analytics.js-integrations#duo-bug
and then `make test-browser` you will see that `ajs == integration` is true which is odd haha.

really hard to test (ajs is really huge), if we had access to the new org we can create repos prefixed with `test-*` and just use those for tests.

``` js
var ajs = require('segmentio/analytics.js');
var integration = require('segmentio/analytics.js-integration');
```

cc @MatthewMueller 
