### PR TITLE
fix files without deps

### DIFF
--- a/lib/duo.js
+++ b/lib/duo.js
@@ -322,7 +322,7 @@ Duo.prototype.dependencies = function *(path, root, out) {
   if (file.mtime == cache.mtime) {
     debug('%s: has not been modified. skip parsing', file.id);
     out[file.id] = cache;
-    paths = values(cache.deps);
+    paths = cache.deps ? values(cache.deps) : [];
     gens = [];
 
     // update the file


### PR DESCRIPTION
Running into an issue where files that don't have a `deps` key in the cache error out. In my case it's an `.svg` file that just looks like:

``` json
"components/segmentio-aphrodite-button@0.1.0/images/arrow-white.svg": {
  "id": "components/segmentio-aphrodite-button@0.1.0/images/arrow-white.svg",
  "type": "svg",
  "mtime": 1392150631000
}
```

Not sure if this code is what we'd want to use to fix the issue, or if it should never even hit that part.
