### PR TITLE
parse.js: Add support for 'provider/user/repo'

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -13,6 +13,7 @@ exports.path = /(.+)/;
 exports.ref = /([A-Za-z0-9-_\/\.$!#%&\(\)\+=]+)/;
 exports.repo = /([A-Za-z0-9-_\.]+)/;
 exports.user = /([A-Za-z0-9-]{1,39})/;
+exports.provider = /([a-z-]+\.[a-z]+)/;
 exports.slug = new RegExp(exports.user.source + '-' + exports.repo.source + '@' + exports.ref.source, 'i');
 
 /**
@@ -25,14 +26,16 @@ var cache = {};
  * Patterns
  */
 
-var patterns = [
-  match('user/repo@ref:path'),
-  match('user/repo@ref'),
-  match('repo@ref:path'),
-  match('user/repo:path'),
-  match('user/repo'),
-  match('repo:path')
+var slugs = [
+  'user/repo@ref:path',
+  'user/repo@ref',
+  'repo@ref:path',
+  'user/repo:path',
+  'user/repo',
+  'repo:path',
 ];
+
+var patterns = slugs.concat(slugs.map(provider)).map(match);
 
 /**
  * Parse a `path`
@@ -50,7 +53,10 @@ function parse(path){
     match = fn(path);
   }
 
-  return cache[path] = match = match || { repo: path };
+  return cache[path] = match = match || {
+    repo: path,
+    provider: 'github.com',
+  };
 }
 
 /**
@@ -63,6 +69,7 @@ function parse(path){
 function match(pattern){
   var parts = pattern.match(/\w+|[^\w]/g);
   var names = pattern.match(/\w+/g);
+
   var source = parts.map(function(part){
     return exports[part] ? exports[part].source : part;
   });
@@ -71,11 +78,22 @@ function match(pattern){
   return function(path){
     var m = regexp.exec(path);
     if (!m) return;
+
     m = m.slice(1);
-    return m.reduce(function(ret, match, i){
+    var match = m.reduce(function(ret, match, i){
       var key = names[i];
       ret[key] = match;
       return ret;
     }, {});
+    match.provider = match.provider || 'github.com';
+    return match;
   };
+}
+
+/**
+ * Prefix `str` with "provider".
+ */
+
+function provider(str) {
+  return 'provider/' + str;
 }

--- a/test/parse.js
+++ b/test/parse.js
@@ -9,7 +9,8 @@ describe('parse()', function(){
         user: 'user',
         repo: 'repo',
         ref: '1.0.0',
-        path: '/index.js'
+        path: '/index.js',
+        provider: 'github.com',
       });
     })
 
@@ -18,7 +19,8 @@ describe('parse()', function(){
         user: 'user',
         repo: 'repo',
         ref: 'v1.0.0',
-        path: '/dist/css'
+        path: '/dist/css',
+        provider: 'github.com',
       });
     })
 
@@ -27,7 +29,8 @@ describe('parse()', function(){
         user: 'user',
         repo: 'repo',
         ref: 'add/feature',
-        path: '/dist/css'
+        path: '/dist/css',
+        provider: 'github.com',
       });
     })
 
@@ -36,7 +39,8 @@ describe('parse()', function(){
         user: 'user',
         repo: 'repo',
         ref: 'add/feature',
-        path: './dist/css'
+        path: './dist/css',
+        provider: 'github.com',
       });
     })
 
@@ -45,9 +49,22 @@ describe('parse()', function(){
         user: 'user',
         repo: 'repo',
         ref: 'add/feature',
-        path: 'dist/css'
+        path: 'dist/css',
+        provider: 'github.com',
       });
     })
+  })
+
+  describe('provider/repo@ref/path', function () {
+    it('should parse correctly', function () {
+      expect(parse('provider.com/user/repo@1.0.0:/index.js')).to.eql({
+        user: 'user',
+        repo: 'repo',
+        ref: '1.0.0',
+        path: '/index.js',
+        provider: 'provider.com',
+      });
+    });
   })
 
   describe('user/repo@ref', function(){
@@ -55,7 +72,19 @@ describe('parse()', function(){
       expect(parse('user/repo@1.0.0')).to.eql({
         user: 'user',
         repo: 'repo',
-        ref: '1.0.0'
+        ref: '1.0.0',
+        provider: 'github.com',
+      });
+    })
+  })
+
+  describe('provider/user/repo@ref', function(){
+    it('should parse correctly', function(){
+      expect(parse('provider.com/user/repo@1.0.0')).to.eql({
+        user: 'user',
+        repo: 'repo',
+        ref: '1.0.0',
+        provider: 'provider.com',
       });
     })
   })
@@ -65,7 +94,19 @@ describe('parse()', function(){
       expect(parse('user/repo:/index.js')).to.eql({
         user: 'user',
         repo: 'repo',
-        path: '/index.js'
+        path: '/index.js',
+        provider: 'github.com',
+      });
+    })
+  })
+
+  describe('provider/user/repo/path', function(){
+    it('should parse correctly', function(){
+      expect(parse('provider.com/user/repo:/index.js')).to.eql({
+        user: 'user',
+        repo: 'repo',
+        path: '/index.js',
+        provider: 'provider.com',
       });
     })
   })
@@ -74,7 +115,18 @@ describe('parse()', function(){
     it('should parse correctly', function(){
       expect(parse('user/repo')).to.eql({
         user: 'user',
-        repo: 'repo'
+        repo: 'repo',
+        provider: 'github.com',
+      });
+    })
+  })
+
+  describe('provider/user/repo', function(){
+    it('should parse correctly', function(){
+      expect(parse('provider.com/user/repo')).to.eql({
+        user: 'user',
+        repo: 'repo',
+        provider: 'provider.com',
       });
     })
   })
@@ -83,6 +135,7 @@ describe('parse()', function(){
     it('should parse correctly', function(){
       expect(parse('repo')).to.eql({
         repo: 'repo',
+        provider: 'github.com',
       });
     })
   })


### PR DESCRIPTION
Not sure how you guys want to handle this, so please review/close/whatever ;)

This is likely the first step to supporting git hosts other than GitHub.  We'll still need to touch duo-package a bit, but there's no sense until duo can determine which provider should be used.

Related: #116.
