### PR TITLE
Adding CLI Plugins Support

### DIFF
--- a/bin/_duo
+++ b/bin/_duo
@@ -57,6 +57,7 @@ var program = new Command('duo')
   .option('-v, --verbose', 'show as much logs as possible', false)
   .option('-c, --concurrency <n>', 'set concurrency, defaulted to 50', 50)
   .option('-o, --output <dir>', 'set the output directory, defaulted to build/', null)
+  .option('-u, --use <plugin>', 'use build plugin', null)
   .parse(process.argv);
 
 /**
@@ -219,6 +220,12 @@ function create(root, entry) {
 
   // output dir
   program.out && duo.assets(program.out);
+
+  if (program.use) {
+    program.use.split(",").forEach(function (plugin) {
+      duo.use(require(plugin.trim())());
+    });
+  }
 
   // installed
   duo.on('install', log('installed'));


### PR DESCRIPTION
This adds support for simple plugins via the CLI. (follows the same API as component 0.x)

``` bash
% duo --use plugin-name
```

Where `plugin-name` is a locally installed npm module. (eg: `<root>/node_modules/<plugin-name>`) You can pass multiple plugins as a comma-separated list.
