### PR TITLE
makefile: dont install deps on test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
+
 BIN := ./node_modules/.bin
 REPORTER ?= spec
 
-test: node_modules
+test:
 	@$(BIN)/gnode $(BIN)/_mocha \
 		--reporter $(REPORTER) \
 		--require co-mocha \

--- a/Readme.md
+++ b/Readme.md
@@ -329,8 +329,9 @@ By using Github as your package manager all of these issues just disappear.
 
 ## Test
 
-```
-make test
+```bash
+$ npm install
+$ make test
 ```
 
 ## License


### PR DESCRIPTION
it slows down testing a bit and shows ugly npm warnings...

cc @MatthewMueller @stephenmathieson 
