### PR TITLE
Fix CLI tests

### DIFF
--- a/test/duo-cli.js
+++ b/test/duo-cli.js
@@ -33,6 +33,14 @@ describe('Duo CLI', function(){
   });
 
   describe('duo ls', function(){
+    before(function *(){
+      yield exec('duo index.js build.js', 'cli-duo-ls');
+    })
+
+    after(function *(){
+      yield remove('cli-duo-ls');
+    })
+
     it('should list all dependencies', function*(){
       out = yield exec('duo ls', 'cli-duo-ls');
       assert(out.stdout, 'expected stdout to be truthy');

--- a/test/fixtures/cli-duo-ls/component.json
+++ b/test/fixtures/cli-duo-ls/component.json
@@ -1,3 +1,4 @@
 {
-  "name": "duo-ls"
+  "name": "duo-ls",
+  "main": "index.js"
 }

--- a/test/fixtures/cli-duo-ls/index.js
+++ b/test/fixtures/cli-duo-ls/index.js
@@ -1,0 +1,1 @@
+hello = 'world'


### PR DESCRIPTION
The _"duo ls"_ test is failing for me:

```
  1) Duo CLI duo ls should list all dependencies:
     AssertionError: expected stdout to be truthy
    at Context.callee$2$0$ (/Users/stephenmathieson/repos/duo/duo/test/duo-cli.js:134:11)
    at Empty.invoke (evalmachine.<anonymous>:148:31)
    at next (/Users/stephenmathieson/repos/duo/duo/node_modules/co/index.js:74:21)
    at /Users/stephenmathieson/repos/duo/duo/node_modules/co/index.js:93:18
    at Object._onImmediate (/Users/stephenmathieson/repos/duo/duo/node_modules/co/index.js:52:14)
    at processImmediate [as _immediateCallback] (timers.js:336:15)


  2) Duo CLI duo duplicates should list all duplicates:
     AssertionError: expected stdout to be truthy
    at Context.callee$2$0$ (/Users/stephenmathieson/repos/duo/duo/test/duo-cli.js:153:11)
    at Empty.invoke (evalmachine.<anonymous>:148:31)
    at next (/Users/stephenmathieson/repos/duo/duo/node_modules/co/index.js:74:21)
    at /Users/stephenmathieson/repos/duo/duo/node_modules/co/index.js:93:18
    at Object._onImmediate (/Users/stephenmathieson/repos/duo/duo/node_modules/co/index.js:52:14)
    at processImmediate [as _immediateCallback] (timers.js:336:15)
```

So I've added a `before()` and an `after()` to ensure the duo.json is generated before we run `$ duo ls`.

Also removing the leftover `.only()` from the CLI suite :p
