### PR TITLE
Makefile: Add a `clean` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,7 @@ test: node_modules
 node_modules: package.json
 	@npm install
 
-.PHONY: test
+clean:
+	rm -rf test/fixtures/*/{components,build.js}
+
+.PHONY: test clean


### PR DESCRIPTION
Removes any side effects from the test suite.

Likely the reason I needed to create #156.
