### PR TITLE
Allowing CLI to work both locally and globally

### DIFF
--- a/bin/duo
+++ b/bin/duo
@@ -3,7 +3,7 @@
 var path = require("path");
 var spawn = require('child_process').spawn;
 
-var gnode = path.resolve(__dirname, "../node_modules/.bin/gnode");
+var gnode = require.resolve("gnode/bin/gnode");
 var duo = path.resolve(__dirname, "_duo");
 var args = [ duo ].concat(process.argv.slice(2));
 


### PR DESCRIPTION
The absolute path being used to find the `gnode` bin only worked globally. (if duo was installed locally, the CLI bombs out very quickly, and without much helpful information)

This uses `require.resolve` to find the correct path for `gnode/bin/gnode`.
