### PR TITLE
refactor entrypoint so duo.entry() is idempotent

### DIFF
--- a/lib/duo.js
+++ b/lib/duo.js
@@ -75,12 +75,12 @@ function Duo(root) {
   this.root = root;
   this.manifestName = 'component.json';
   this.manifestPath = join(root, this.manifestName);
+  this.manifest = this.json(this.manifestPath);
   this.installPath = join(root, 'components');
   this.mappingPath = join(this.installPath, 'duo.json');
-  this.rootjson = this.json(this.manifestPath);
   this.assetPath = join(root, 'build');
   this._concurrency = 50;
-  this.entrypoint = null;
+  this.entryFile = null;
   this.symlinks = [];
   this.includes = {};
   Emitter.call(this);
@@ -105,7 +105,7 @@ Duo.prototype.__proto__ = Emitter.prototype;
  */
 
 Duo.prototype.entry = function(entry) {
-  this.entrypoint = this.file({ path: entry });
+  this.entryFile = this.file({ path: entry, entry: true });
   return this;
 };
 
@@ -121,7 +121,7 @@ Duo.prototype.entry = function(entry) {
 Duo.prototype.src = function(src, type) {
   type = type || langmap[detect(src)];
   if (!type) throw error('could not detect a supported type on this source');
-  this.entrypoint = this.file({ raw: src, type: type });
+  this.entryFile = this.file({ raw: src, type: type, entry: true });
   return this;
 };
 
@@ -250,7 +250,7 @@ Duo.prototype.include = function(name, src) {
 
 Duo.prototype.write = unyield(function *() {
   var src = yield this.run();
-  var rel = this.entrypoint.id;
+  var rel = this.entryFile.id;
   var path = join(this.assetPath, rel);
   yield mkdir(dirname(path));
   yield fs.writeFile(path, src);
@@ -266,12 +266,12 @@ Duo.prototype.write = unyield(function *() {
  */
 
 Duo.prototype.run = unyield(function *() {
-  if (!this.entrypoint) return '';
+  if (!this.entryFile) return '';
 
   var mapping = Mapping(this.mappingPath);
   var manifestName = this.manifestName;
   var global = this.global();
-  var file = this.entrypoint;
+  var file = this.entryFile;
   var rel = file.id;
 
   // idempotent across runs
@@ -383,7 +383,7 @@ Duo.prototype.dependencies = function *(file, out) {
     depmap[dep] = this.dependency(dep, file);
   }
 
-  // resolve dependency entrypoints,
+  // resolve dependencies from entry files,
   // and remove unresolved deps
   depmap = compact(yield depmap);
   paths = values(depmap);
@@ -420,8 +420,8 @@ Duo.prototype.recurse = function(paths, out) {
     path = resolve(this.root, path);
 
     file = this.file({
-      path: path,
-      root: this.findroot(path)
+      root: this.findroot(path),
+      path: path
     });
 
     gens.push(this.dependencies(file, out));
@@ -483,25 +483,25 @@ Duo.prototype.dependency = function *(dep, file) {
  */
 
 Duo.prototype.resolve = function*(dep, root, path) {
-  var entrypoint = this.entrypoint;
-  var ext = extension(dep) ? '' : '.' + entrypoint.type;
+  var entry = this.entryFile;
+  var ext = extension(dep) ? '' : '.' + entry.type;
   var ret;
 
   if (this.manifestName == basename(dep)) {
     // component
     var json = this.json(resolve(root, dep));
-    var entrypoint = main(json, entrypoint.type) || 'index.' + entrypoint.type;
-    return resolve(root, dirname(dep), entrypoint);
+    var entry = main(json, entry.type) || 'index.' + entry.type;
+    return resolve(root, dirname(dep), entry);
   } else if ('/' == dep[0]) {
     // absolute (to this.root)
-    ret = resolve(entrypoint.root, dep);
+    ret = resolve(entry.root, dep);
   } else if ('../' == dep.slice(0, 3)) {
     // relative
     ret = resolve(dirname(path), dep);
   } else if ('./' == dep.slice(0, 2)) {
     // relative
     ret = resolve(dirname(path), dep);
-  } else if ('css' == entrypoint.type && (yield relative(resolve(root, dep)))) {
+  } else if ('css' == entry.type && (yield relative(resolve(root, dep)))) {
     // hack to support relative paths without "./"
     // lots of for CSS urls with no "./" unfortunately
     // example "fonts/whatever"
@@ -543,7 +543,7 @@ Duo.prototype.resolve = function*(dep, root, path) {
 
 Duo.prototype.file = function(attrs) {
   attrs.root = attrs.root || this.root;
-  return new File(attrs, this.entrypoint, this);
+  return new File(attrs, this);
 }
 
 /**
@@ -594,7 +594,7 @@ Duo.prototype.finddeps = function(gh, json) {
   var deps = json.dependencies || {};
   var rext = '([\.][a-z]+)?';
 
-  if (this.dev && json == this.rootjson) {
+  if (this.dev && json == this.manifest) {
     deps = extend(deps, json.development || {});
   }
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -40,28 +40,24 @@ var fields = 'id,type,mtime,src,deps,entry';
  * Initialize `File`
  *
  * @param {Object} attrs
- * @param {File} entrypoint
  * @param {Duo} duo
  * @return {File}
  * @api public
  */
 
-function File(attrs, entrypoint, duo) {
-  if (!(this instanceof File)) return new File(attrs, entrypoint, duo);
+function File(attrs, duo) {
+  if (!(this instanceof File)) return new File(attrs, duo);
   this.attrs = clone(attrs || {});
-  this.entrypoint = entrypoint;
   this.duo = duo;
 
-  var root = entrypoint ? entrypoint.root : this.root;
   var type = attrs.type ? '.' + attrs.type : '';
   var path = attrs.path || 'source' + type;
 
   // initial attrs
-  this.attrs.path = resolve(root, path);
+  this.attrs.path = resolve(attrs.root, path);
   this.attrs.type = attrs.type || extension(this.path);
-  this.attrs.id = relative(root, this.path);
+  this.attrs.id = relative(duo.root, this.path);
   this.attrs.mtime = attrs.mtime || this.modified(this.path);
-  this.attrs.entry = !entrypoint;
 }
 
 /**
@@ -109,7 +105,8 @@ File.prototype.load = function *() {
     || (yield fs.readFile(this.path, 'utf8'));
 
   // transform the file and update attributes
-  var res = yield transform.run(this, this.entrypoint || this);
+  var entry = this.entry ? this : this.duo.entryFile;
+  var res = yield transform.run(this, entry);
   this.set(res[0].json());
 
   return this;
@@ -151,6 +148,7 @@ File.prototype.set = function(attrs) {
 File.prototype.json =
 File.prototype.toString = function() {
   var json = clone(this.attrs);
+  if (!json.entry) delete json.entry;
   return mask(json, fields);
 };
 

--- a/test/api.js
+++ b/test/api.js
@@ -50,21 +50,34 @@ describe('Duo API', function(){
     assert.deepEqual(['one', 'two'], ctx.main);
   });
 
-  it('.entry(file) should work with full paths', function*() {
-    var entry = join(path('simple'), 'index.js');
-    var js = yield build('simple', entry).run();
-    var ctx = evaluate(js);
-    assert.deepEqual(['one', 'two'], ctx.main);
-  })
+  describe('.entry(file)', function() {
+    it('should work with full paths', function*() {
+      var entry = join(path('simple'), 'index.js');
+      var js = yield build('simple', entry).run();
+      var ctx = evaluate(js);
+      assert.deepEqual(['one', 'two'], ctx.main);
+    })
 
-  it('.entry(file) should throw if file doesn\'t exist', function *() {
-    var duo = Duo(__dirname).entry('zomg.js');
+    it('should throw if file doesn\'t exist', function *() {
+      var duo = Duo(__dirname).entry('zomg.js');
 
-    try {
-      yield duo.run();
-    } catch (e) {
-      assert(~e.message.indexOf('cannot find entry: zomg.js'));
-    }
+      try {
+        yield duo.run();
+      } catch (e) {
+        assert(~e.message.indexOf('cannot find entry: zomg.js'));
+      }
+    })
+
+    it('should be idempotent', function *() {
+      var root = path('simple');
+      var duo = Duo(root).entry('hi.js');
+      duo.entry('index.js');
+      var js = yield duo.run();
+      var ctx = evaluate(js);
+      assert.deepEqual(['one', 'two'], ctx.main);
+      var json = yield mapping('simple');
+      assert(true == json['index.js'].entry);
+    })
   })
 
   it('should build with no deps', function *() {


### PR DESCRIPTION
This was kind of a nasty bug I just ran into, basically the way it was implemented if you did:

``` js
Duo(__dirname)
  .entry(undefined)
  .entry('index.js')
```

`index.js` would not be considered an `entry`. This refactor fixes that bug and hopefully makes the code easier to reason through.
