### PR TITLE
add node_modules to default makefile task so it installs node_modules if not installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ test: node_modules
 
 node_modules: package.json
 	@npm install
+	@touch node_modules
 
 coverage: $(SRC) $(TESTS)
 	@$(BIN)/gnode $(BIN)/istanbul cover \


### PR DESCRIPTION
just makes it so `make` or `make test` will work right when you clone the repo :)
