### PR TITLE
fix watch to repeat the original command

### DIFF
--- a/bin/_duo
+++ b/bin/_duo
@@ -116,16 +116,22 @@ var bin = ['duo', command].join('-');
 var quiet = program.quiet;
 
 /**
- * Watch flag
- */
-
-var watch = program.watch;
-
-/**
  * Root
  */
 
 var root = findroot(program.root);
+
+/**
+ * Asset path
+ */
+
+var outdir = assets(program.args);
+
+/**
+ * Watching
+ */
+
+var watching = false;
 
 /**
  * Custom executable
@@ -171,13 +177,9 @@ else if (!process.stdin.isTTY) input();
 else program.help();
 
 /**
- * Watch for any other changes
- */
-
-watch && Watch(root).watch(build);
-
-/**
  * Accept standard input
+ *
+ * @api private
  */
 
 function input() {
@@ -194,56 +196,73 @@ function input() {
 }
 
 /**
- * Build file(s)
+ * Build the entries
  *
- * @param {Array|String} entries
+ * @param {Array} entries
  * @api private
  */
 
 function build(entries) {
+  outdir && entries.pop();
+  switch (entries.length) {
+    case 0: return program.help();
+    case 1: return print(entries[0]);
+    default: return write(entries);
+  }
+}
+
+/**
+ * Print to stdout
+ *
+ * @param {String} entry
+ * @api private
+ */
+
+function print(entry) {
+  create(entry).run(function(err, src) {
+    if (err) return error(err);
+    logger.end();
+    stdout.write(src);
+
+    // watch or exit
+    program.watch
+      ? watch(print)
+      : process.exit(0);
+  });
+}
+
+/**
+ * Write the entries
+ *
+ * @param {Array} entries
+ * @api private
+ */
+
+function write(entries) {
   entries = 'string' == typeof entries ? [entries] : entries;
 
   var batch = new Batch;
-  var len = entries.length;
-  var last = entries[len - 1];
   var push = batch.push.bind(batch);
-  var out = !isFile(last) ? entries.pop() : false;
 
-  // no entries to build
-  !len && program.help();
+  var duos = entries
+    .map(multiple)
+    .map(push);
 
-  // write to standard out
-  if (1 == len) {
-    var duo = create(entries[0]);
-    duo.run(function(err, src) {
-      if (err) return error(err);
-      logger.end();
-      stdout.write(src);
-      !watch && process.exit(0);
-    });
-  }
+  batch.end(function(err) {
+    if (err) return error(err);
+    logger.end();
 
-  // write multiple files to
-  // `out` or `duo.assets()`
-  if (len > 1) {
-    var duos = entries
-      .map(multiple)
-      .map(push);
-
-    batch.end(function(err) {
-      if (err) return error(err);
-      logger.end();
-      !watch && process.exit(0);
-    });
-  }
+    // watch or exit
+    program.watch
+      ? Watch(root).watch(write)
+      : process.exit(0);
+  });
 
   // write multiple entries to
   // the directory `out`
   function multiple(entry) {
     return function(done) {
-      var duo = create(entry);
-      out && duo.assets(out);
-      duo.write(done);
+      create(entry).write(done);
     }
   }
 }
@@ -273,6 +292,7 @@ function create(entry) {
   }
 
   // output dir
+  outdir && duo.assets(outdir);
   program.out && duo.assets(program.out);
 
   if (program.use) {
@@ -290,6 +310,19 @@ function create(entry) {
   }
 
   return duo;
+}
+
+/**
+ * Watch
+ *
+ * @param {Function} action
+ * @api private
+ */
+
+function watch(action) {
+  if (watching) return;
+  watching = true;
+  Watch(root).watch(action);
 }
 
 /**
@@ -335,6 +368,22 @@ function findroot(root) {
   return '/' == path
     ? cwd
     : path;
+}
+
+/**
+ * Check if `entries` contains
+ * an asset path
+ *
+ * @param {Array} entries
+ * @return {String|Boolean}
+ * @api private
+ */
+
+function assets(entries) {
+  if (!entries.length) return false;
+  var len = entries.length;
+  var last = entries[len - 1];
+  return !isFile(last) && last;
 }
 
 /**

--- a/test/cli.js
+++ b/test/cli.js
@@ -22,6 +22,7 @@ describe('Duo CLI', function(){
   describe('duo in.js', function(){
     it('should write to stdout', function *(){
       out = yield exec('duo index.js', 'cli-duo');
+      if (out.error) throw out.error;
       assert(out.stdout);
       assert(out.stderr);
       ctx = evaluate(out.stdout);
@@ -30,6 +31,7 @@ describe('Duo CLI', function(){
 
     it('should support opts', function *() {
       out = yield exec('duo -c 20 -t js index.js', 'cli-duo');
+      if (out.error) throw out.error;
       assert(out.stdout);
       assert(out.stderr);
       ctx = evaluate(out.stdout);
@@ -44,14 +46,15 @@ describe('Duo CLI', function(){
 
     it('should ignore unexpanded globs', function *() {
       var out = yield exec('duo *.css', 'entries');
+      if (out.error) throw out.error;
       assert(!out.stderr);
-      assert(!out.error);
     })
   });
 
   describe('duo [file, ...]', function() {
     it('should build multiple entries to duo.assets()', function *() {
       var out = yield exec('duo *.js', 'entries');
+      if (out.error) throw out.error;
       var admin = yield build('entries/build/admin.js')
       var index = yield build('entries/build/index.js')
       assert('admin' == admin.main);
@@ -67,6 +70,7 @@ describe('Duo CLI', function(){
       var out = yield exec('duo -c 20 *.js', 'entries');
       var admin = yield build('entries/build/admin.js')
       var index = yield build('entries/build/index.js')
+      if (out.error) throw out.error;
       assert('admin' == admin.main);
       assert('index' == index.main);
       assert(contains(out.stderr, 'building : admin.js'));
@@ -80,6 +84,7 @@ describe('Duo CLI', function(){
       var out = yield exec('duo *.js *.css', 'entries');
       var admin = yield build('entries/build/admin.js')
       var index = yield build('entries/build/index.js')
+      if (out.error) throw out.error;
       assert('admin' == admin.main);
       assert('index' == index.main);
       assert(contains(out.stderr, 'building : admin.js'));
@@ -96,6 +101,7 @@ describe('Duo CLI', function(){
       var out = yield exec('duo *.js out', 'entries');
       var admin = yield build('entries/out/admin.js')
       var index = yield build('entries/out/index.js')
+      if (out.error) throw out.error;
       assert('admin' == admin.main);
       assert('index' == index.main);
       assert(contains(out.stderr, 'building : admin.js'));
@@ -110,6 +116,7 @@ describe('Duo CLI', function(){
       var out = yield exec('duo -c 20 *.js out', 'entries');
       var admin = yield build('entries/out/admin.js')
       var index = yield build('entries/out/index.js')
+      if (out.error) throw out.error;
       assert('admin' == admin.main);
       assert('index' == index.main);
       assert(contains(out.stderr, 'building : admin.js'));
@@ -122,6 +129,7 @@ describe('Duo CLI', function(){
 
     it('should ignore unexpanded globs', function *() {
       var out = yield exec('duo *.js *.css out', 'entries');
+      if (out.error) throw out.error;
       var admin = yield build('entries/out/admin.js')
       var index = yield build('entries/out/index.js')
       assert('admin' == admin.main);
@@ -139,6 +147,7 @@ describe('Duo CLI', function(){
   describe('duo < in.js', function() {
     it('should write to stdout', function *() {
       out = yield exec('duo < index.js', 'cli-duo');
+      if (out.error) throw out.error;
       assert(out.stdout);
       assert(out.stderr);
       ctx = evaluate(out.stdout);
@@ -149,6 +158,7 @@ describe('Duo CLI', function(){
   describe('--quiet', function() {
     it('should not log info to stderr', function *() {
       out = yield exec('duo -q index.js > build.js', 'cli-duo');
+      if (out.error) throw out.error;
       ctx = yield build('cli-duo');
       assert('cli-duo' == ctx.main);
       assert(!out.stderr.trim());
@@ -174,6 +184,7 @@ describe('Duo CLI', function(){
 
     it('should list all dependencies', function*(){
       out = yield exec('duo -q index.js > build.js && duo ls', 'cli-duo-ls');
+      if (out.error) throw out.error;
       assert(contains(out.stdout, 'duo-ls'), 'duo-ls');
       assert(contains(out.stdout, '├── a.js'), '├── a.js');
       assert(contains(out.stdout, '└── b.js'), '└── b.js');
@@ -185,6 +196,7 @@ describe('Duo CLI', function(){
   describe('duo duplicates', function(){
     it('should list all duplicates', function*(){
       out = yield exec('duo -q index.js > build.js && duo duplicates', 'cli-duo-ls');
+      if (out.error) throw out.error;
       assert(contains(out.stdout, 'total duplicates : 0b'));
       assert(!out.stderr.trim());
       rm('cli-duo-ls/build.js');


### PR DESCRIPTION
Changes:
- Fixed watch to run the original command.
- Refactored the CLI a bit to support "replayed" commands
- Added `out.error` throwing so it's easier to see errors in mocha (this is still not ideal, see: https://github.com/component/duo/issues/195
