### PR TITLE
Added example of using 'watch' option

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -31,8 +31,14 @@ $ duo in.css > out.css
 # build all files to duo.assets() (default: build/)
 $ duo *.{js,css}
 
+# watch all files and build to duo.assets()
+$ duo watch *.{js,css}
+
 # build all files to the out/ folder
 $ duo *.{js,css} out
+
+# watch all files and build to the out/ folder
+$ duo watch *.{js,css} out
 
 # build from stdin and output out.css
 $ duo < in.css > out.css


### PR DESCRIPTION
Added example of using the 'watch' option.

I noticed that omitting the '.' before the extension type still works ( `duo watch *{js,css}` and `duo *{js,css}`), so I'm now wondering if it's even needed?

Loving what you've made here, good stuff!
