### PR TITLE
support require('..'). closes: #231

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,6 @@ coverage: $(SRC) $(TESTS)
 	    --timeout 5s
 
 clean:
-	rm -rf coverage test/fixtures/*/{components,deps,out,build.js}
+	@rm -rf coverage test/fixtures/*/{components,deps,out,build.js}
 
 .PHONY: test clean

--- a/lib/duo.js
+++ b/lib/duo.js
@@ -544,7 +544,7 @@ Duo.prototype.resolve = function*(dep, root, path) {
   } else if ('/' == dep[0]) {
     // absolute (to this.root)
     ret = resolve(entry.root, dep);
-  } else if ('../' == dep.slice(0, 3)) {
+  } else if ('..' == dep.slice(0, 2)) {
     // relative
     ret = resolve(dirname(path), dep);
   } else if ('./' == dep.slice(0, 2)) {

--- a/test/api.js
+++ b/test/api.js
@@ -99,6 +99,12 @@ describe('Duo API', function(){
     assert('resolved' == ctx.main);
   })
 
+  it('should resolve dependencies like require("..")', function *() {
+    var js = yield build('relative-path', 'test/test.js').run();
+    var ctx = evaluate(js);
+    assert('index' == ctx.main);
+  })
+
   it('should fetch and build direct dependencies', function*(){
     this.timeout(15000);
     var js = yield build('simple-deps').run();

--- a/test/fixtures/relative-path/index.js
+++ b/test/fixtures/relative-path/index.js
@@ -1,0 +1,1 @@
+module.exports = 'index';

--- a/test/fixtures/relative-path/test/test.js
+++ b/test/fixtures/relative-path/test/test.js
@@ -1,0 +1,1 @@
+module.exports = require('..');


### PR DESCRIPTION
Fix `duo#resolve` to support `require('..')`.
