### PR TITLE
Fixed hanging on windows when there is no manifest

### DIFF
--- a/bin/_duo
+++ b/bin/_duo
@@ -370,7 +370,7 @@ function error(err) {
 function findroot(root) {
   if (root) return resolve(cwd, root);
   var sep = require('path').sep;
-  var parts = cwd.split(/[\/\\]+/);
+  var parts = cwd.split(sep);
   var path = cwd;
 
   while (!exists(join(path, 'component.json')) && parts.length > 1) {


### PR DESCRIPTION
`findroot()` was getting into an infinite loop on windows, because this would never end:

``` js
while (!exists(join(path, 'component.json')) && '/' != path) {
  path = dirname(path);
}
```

as windows root is not `/`.

At first I've tried using regexp, but than figured the path splitting approach would be more robust as there might be different path types, like `\\NETWORK\dir` and what not...
