### PR TITLE
Fixes a npm warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,5 +56,9 @@
     "styl": "^0.2.7",
     "map-stream": "~0.1.0",
     "gulp": "~3.8.7"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/duojs/duo.git"
   }
 }


### PR DESCRIPTION
**npm** is displaying a warn message for missing repository field after having installed **duo@0.8.1**

This PR fixes that by adding a **repository** property on the `package.json` file containing the correct information.
