### PR TITLE
fix cli to use program.output instead of program.out

### DIFF
--- a/bin/_duo
+++ b/bin/_duo
@@ -305,7 +305,7 @@ function create(entry) {
 
   // output dir
   outdir && duo.assets(outdir);
-  program.out && duo.assets(program.out);
+  program.output && duo.assets(program.output);
 
   // use plugins
   plugins.forEach(function (plugin) {


### PR DESCRIPTION
`program.out` is always undefined since the flag is `--output`. 
