### PR TITLE
default to index.css instead of styles[0]

### DIFF
--- a/lib/duo.js
+++ b/lib/duo.js
@@ -539,7 +539,16 @@ Duo.prototype.resolve = function*(dep, root, path) {
   if (this.manifestName == basename(dep)) {
     // component
     var json = this.json(resolve(root, dep));
-    var entry = main(json, entry.type) || 'index.' + entry.type;
+    var entry;
+    if ('css' == entry.type) {
+      var fallback = main(json, entry.type);
+      entry = 'index.css';
+      var resolved = resolve(root, dirname(dep), entry);
+      if (yield exists([resolved])) return resolved;
+      if (fallback) entry = fallback;
+    } else {
+      entry = main(json, entry.type) || 'index.' + entry.type;
+    }
     return resolve(root, dirname(dep), entry);
   } else if ('/' == dep[0]) {
     // absolute (to this.root)


### PR DESCRIPTION
@MatthewMueller this is all it would take. 5 tests don't pass with this though so it will probably expand some. but, this solves the problem of being able to support both legacy component and the new `@import` style, so you can port stuff from component to duo without breaking anything in the process.
