### PR TITLE
_duo: Fix --quiet flag when --use'ing plugins

### DIFF
--- a/bin/_duo
+++ b/bin/_duo
@@ -447,7 +447,7 @@ function usePlugins(use) {
       var npm = resolve(root, "node_modules", plugin);
 
       var mod = require(exists(local) ? local : npm);
-      logger.using(plugin);
+      !quiet && logger.using(plugin);
       return mod();
     } catch (e) {
       error(e);

--- a/test/cli.js
+++ b/test/cli.js
@@ -210,6 +210,17 @@ describe('Duo CLI', function(){
       assert(~out.stderr.indexOf('Error: cannot find entry: zomg.js'));
       assert(out.error);
     })
+
+    describe.only('with --use', function () {
+      it('should not log "using : <plugin>"', function *() {
+        var out = yield exec(
+            'duo --quiet --use plugin.js index.js > build.js'
+          , 'cli-duo'
+        );
+        assert('' == out.stdout);
+        assert('' == out.stderr.trim());
+      })
+    });
   });
 
   describe('duo --use <plugin>', function() {

--- a/test/fixtures/cli-duo/plugin.js
+++ b/test/fixtures/cli-duo/plugin.js
@@ -1,0 +1,4 @@
+
+module.exports = function(){
+  return function(){};
+};


### PR DESCRIPTION
current impl doesn't respect `--quiet` anymore:

``` sh
$ bin/duo --use duo-stylus -q -t css < index.styl > out.css

        using : duo-stylus

```
