### PR TITLE
ignore unresolved remote dependency paths

### DIFF
--- a/lib/duo.js
+++ b/lib/duo.js
@@ -519,7 +519,14 @@ Duo.prototype.dependency = function *(dep, file) {
   // path
   var path = pkg.path(parse(dep).path || 'component.json');
   var resolved = yield this.resolve(path, pkg.path(), path);
-  return relative(root, resolved);
+
+  // logging
+  !resolved && debug('%s: cannot resolve "%s"', file.id, dep);
+
+  // return resolved or false
+  return resolved
+    ? relative(root, resolved)
+    : false;
 };
 
 /**
@@ -540,7 +547,7 @@ Duo.prototype.resolve = function*(dep, root, path) {
     // component
     var json = this.json(resolve(root, dep));
     var entry = main(json, entry.type) || 'index.' + entry.type;
-    return resolve(root, dirname(dep), entry);
+    ret = resolve(root, dirname(dep), entry);
   } else if ('/' == dep[0]) {
     // absolute path (relative to app/component root)
     var relroot = this.findroot(path);

--- a/test/api.js
+++ b/test/api.js
@@ -603,6 +603,13 @@ describe('Duo API', function(){
       var out = read('css-dup-asset/index.out.css');
       assert(css.trim() == out.trim());
     })
+
+    it('should ignore unresolved remote paths', function *() {
+      var duo = build('css-ignore-unresolved', 'index.css');
+      var css = yield duo.run();
+      var out = read('css-ignore-unresolved/index.out.css');
+      assert(css == out);
+    })
   })
 
   describe('json', function() {

--- a/test/fixtures/css-ignore-unresolved/index.css
+++ b/test/fixtures/css-ignore-unresolved/index.css
@@ -1,0 +1,13 @@
+/**
+ * Module dependencies
+ */
+
+@import "necolas/normalize.css:zomg.css";
+
+/**
+ * Styles
+ */
+
+body {
+  background: teal;
+}

--- a/test/fixtures/css-ignore-unresolved/index.out.css
+++ b/test/fixtures/css-ignore-unresolved/index.out.css
@@ -1,0 +1,13 @@
+/**
+ * Module dependencies
+ */
+
+@import "necolas/normalize.css:zomg.css";
+
+/**
+ * Styles
+ */
+
+body {
+  background: teal;
+}


### PR DESCRIPTION
Right now the following will error out:

``` css
@import "necolas/normalize:omg.css";
```

The rest of the time, Duo will ignore an unresolved path. This PR makes that behavior consistent for the above case.
