### PR TITLE
extract deps and files in a similar way

### DIFF
--- a/lib/duo.js
+++ b/lib/duo.js
@@ -90,6 +90,7 @@ function Duo(root) {
   this.dev = false;
   this.tok = null;
   this.files = [];
+  this.deps = {};
 
   // plugins
   this.plugins = new Step;
@@ -315,6 +316,7 @@ Duo.prototype.run = unyield(function *() {
 
   // idempotent across runs
   this.files = [];
+  this.deps = {};
 
   // add core plugins
   this
@@ -330,23 +332,23 @@ Duo.prototype.run = unyield(function *() {
   }
 
   // 3) Fetch the dependency map
-  var deps = yield this.dependencies(file);
+  yield this.dependencies(file);
 
   // includes to mapping
-  deps = extend(deps, this.includes);
+  extend(this.deps, this.includes);
 
   // add global
-  if (global) deps[rel].global = global;
+  if (global) this.deps[rel].global = global;
 
   // write out the asset files
   yield this.files;
 
   // write out mapping
   yield mkdir(this.installPath);
-  deps = yield mapping.update(deps);
+  this.deps = yield mapping.update(this.deps);
 
   // pack the mapping
-  var pack = Pack(deps);
+  var pack = Pack(this.deps);
   this.dev && pack.development();
   var src = pack.pack(rel);
 
@@ -358,16 +360,14 @@ Duo.prototype.run = unyield(function *() {
 });
 
 /**
- * Get all the dependencies of a `file` and install them to `out`.
+ * Get all the dependencies of a `file`.
  *
  * @param {File} file
- * @param {Object} out
- * @return {Object}
  * @api private
  */
 
-Duo.prototype.dependencies = function *(file, out) {
-  out = out || {};
+Duo.prototype.dependencies = function *(file) {
+  var out = this.deps;
 
   var cache = clone(this.mapping[file.id] || {});
   var includes = this.includes;
@@ -380,13 +380,13 @@ Duo.prototype.dependencies = function *(file, out) {
   // already visited
   if (out[file.id]) {
     debug('%s, already parsed. ignoring', file.id);
-    return out;
+    return;
   }
 
   // included manually
   if (cache.include) {
     out[file.id] = cache;
-    return out;
+    return;
   }
 
   // check if the file has been modified
@@ -403,9 +403,9 @@ Duo.prototype.dependencies = function *(file, out) {
     !rsupported.test(file.type) && this.files.push(this.bundle(file.id));
 
     // recurse the dependency's dependencies
-    var gens = this.recurse(paths, out);
+    var gens = this.recurse(paths);
     yield this.parallel(gens);
-    return out;
+    return;
   }
 
   // load the file
@@ -418,7 +418,7 @@ Duo.prototype.dependencies = function *(file, out) {
     this.files.push(this.bundle(file.id));
     delete file.attrs.src;
     out[file.id] = file.json();
-    return out;
+    return;
   }
 
   // Parse content for dependencies
@@ -444,21 +444,20 @@ Duo.prototype.dependencies = function *(file, out) {
   out[file.id] = file.json();
 
   // recurse the dependency's dependencies
-  var gens = this.recurse(paths, out);
+  var gens = this.recurse(paths);
   yield this.parallel(gens);
-  return out;
+  return;
 };
 
 /**
  * Create generators to recurse the next layer of dependencies.
  *
  * @param {Array} paths
- * @param {Object} out
  * @return {Array}
  * @api private
  */
 
-Duo.prototype.recurse = function (paths, out) {
+Duo.prototype.recurse = function (paths) {
   var includes = this.includes;
   var gens = [];
   var path;
@@ -473,7 +472,7 @@ Duo.prototype.recurse = function (paths, out) {
       path: path
     });
 
-    gens.push(this.dependencies(file, out));
+    gens.push(this.dependencies(file));
   }
 
   return gens;


### PR DESCRIPTION
This one just removes the `out` variable that is passed through some of the methods, and makes it work similar to how the `this.files` prop does. It makes it a little clearer what's going on hopefully. Later on it would be ideal if the `Duo` object didn't keep track of state, but that would require some more work probably. All tests pass woohoo!

/cc @MatthewMueller @ianstormtaylor 
