### PR TITLE
4 break-apart/methods

### DIFF
--- a/lib/duo.js
+++ b/lib/duo.js
@@ -578,7 +578,7 @@ Duo.prototype.resolveSource = function *(file, json) {
 
   // resolve dependencies from entry files,
   // and remove unresolved deps
-  paths = values(depmap);
+  var paths = values(depmap);
 
   // update the file with the resolved dependencies
   file.set({ deps: depmap });


### PR DESCRIPTION
@MatthewMueller @ianstormtaylor this one is a bit more complex. in here, all that's going on basically is breaking apart the large methods into smaller chunks, so it's easier to reason about what's happening under the hood. once we have these smaller, more single-purpose methods, it'll hopefully become clearer how to simplify even further.

I also renamed some of the main (but I'm assuming private) methods:

```
resolve -> resolveDependencyPath
dependency -> resolveDependency
dependencies -> resolve
```

So now the new methods are:
- `resolve`: this is the main one that gets called for each file. it parses the dependencies and does everything to "resolve" the file
- `resolveDependency`: this is called for each dependency, the thing that gets parsed out of the file, using `file.dependencies()`. so really this is just some string that can point to http path, local file/asset, remote dependency. so then this is broken up into those 3 methods, `resolveLocalPath`, `resolveRemotePath`, etc.
- `resolveDependencyPath`: this is still a complex method, but essentially all it's doing is taking a string, and returning the full local, relative path. it was called "resolve" before, but that was hard to wrap my mind around.

These verbose methods aren't the most beautiful things in the world, but they're a step toward simplifying it a bit. Didn't want to go much further until we can merge this if you guys are cool with it. What do you think?

Also this doesn't change functionality at all I don't think, still just breaking apart the code and renaming a few things. Tests still all pass. If you're feeling bold we can merge just this one instead of the other 3 before it :-)
