### PR TITLE
5 compile/dependencies

### DIFF
--- a/lib/duo.js
+++ b/lib/duo.js
@@ -64,6 +64,7 @@ var rsupported = /^(js|css)$/;
 function Duo(root) {
   if (!(this instanceof Duo)) return new Duo(root);
   if (!root) throw error('duo requires a root directory');
+  Emitter.call(this);
   this.root(root);
   this.manifest('component.json');
   this.installTo('components');
@@ -73,11 +74,10 @@ function Duo(root) {
   this.concurrency(50);
 
   this.files = [];
+  this.output = {};
   this.mapping = {};
   this.includes = {};
   this.json = readJson(this.path('component.json'));
-
-  Emitter.call(this);
 
   // plugins
   this.plugins = new Step;
@@ -381,6 +381,7 @@ Duo.prototype.run = unyield(function *() {
 
   // idempotent across runs
   this.files = [];
+  this.output = {};
 
   // add core plugins
   this
@@ -396,24 +397,27 @@ Duo.prototype.run = unyield(function *() {
   }
 
   // 3) Fetch the dependency map
-  var deps = yield this.dependencies(file);
+  yield this.resolve(file);
 
   // includes to mapping
-  deps = extend(deps, this.includes);
+  extend(this.output, this.includes);
 
   // add global
-  if (global) deps[rel].global = global;
+  if (global) this.output[rel].global = global;
+
+  // compute dependencies
+  this.compileDependencies();
 
   // write out the asset files
   yield this.files;
 
   // write out mapping
   yield mkdir(this.installPath());
-  deps = yield mapping.update(deps);
+  this.output = yield mapping.update(this.output);
 
   // pack the mapping
-  var pack = Pack(deps);
-  this.development() && pack.development();
+  var pack = Pack(this.output);
+  if (this.development()) pack.development();
   var src = pack.pack(rel);
 
   // logging
@@ -427,168 +431,249 @@ Duo.prototype.run = unyield(function *() {
  * Get all the dependencies of a `file` and install them to `out`.
  *
  * @param {File} file
- * @param {Object} out
  * @return {Object}
  * @api private
  */
 
-Duo.prototype.dependencies = function *(file, out) {
-  out = out || {};
-
-  var cache = clone(this.mapping[file.id] || {});
-  var includes = this.includes;
-  var paths = [];
-  var gens = [];
-
-  // logging
-  debug('parsing: %s', file.id)
-
-  // already visited
-  if (out[file.id]) {
-    debug('%s, already parsed. ignoring', file.id);
-    return out;
-  }
-
-  // included manually
-  if (cache.include) {
-    out[file.id] = cache;
-    return out;
-  }
-
-  // check if the file has been modified
-  if (file.mtime == cache.mtime) {
-    debug('%s: has not been modified. skip parsing', file.id);
-    out[file.id] = cache;
-    paths = values(cache.deps);
-    gens = [];
-
-    // update the file
-    file.set(cache);
-
-    // if a non-supported file type, bundle
-    !rsupported.test(file.type) && this.files.push(this.bundle(file.id));
-
-    // recurse the dependency's dependencies
-    var gens = this.recurse(paths, out);
-    yield this.parallel(gens);
-    return out;
-  }
-
-  // load the file
+Duo.prototype.resolve = function *(file) {
+  debug('parsing: %s', file.id);
+  var json = clone(this.mapping[file.id] || {});
+  if (yield this.resolvedLocally(file, json)) return;
+  if (yield this.resolvedFromCache(file, json)) return;
   yield file.load();
-
-  // Not a supported file type, don't parse any farther
-  // But include in duo.json, for symlinking / copying
-  if (!rsupported.test(file.type)) {
-    if (file.entry) throw error('%s: ".%s" not supported', file.id, file.type);
-    this.files.push(this.bundle(file.id));
-    delete file.attrs.src;
-    out[file.id] = file.json();
-    return out;
-  }
-
-  // Parse content for dependencies
-  var deps = file.dependencies();
-  var depmap = {};
-
-  // logging
-  debug('%s deps: %j', file.id, deps)
-
-  // download and resolve the dependencies
-  for (var i = 0, dep; dep = deps[i++];) {
-    depmap[dep] = includes[dep] ? dep : this.dependency(dep, file, this.entry());
-  }
-
-  // resolve dependencies from entry files,
-  // and remove unresolved deps
-  depmap = compact(yield depmap);
-  paths = values(depmap);
-  gens = [];
-
-  // update the file with the resolved dependencies
-  file.set({ deps: depmap });
-  out[file.id] = file.json();
-
-  // recurse the dependency's dependencies
-  var gens = this.recurse(paths, out);
-  yield this.parallel(gens);
-  return out;
+  if (yield this.resolveAsset(file, json)) return;
+  yield this.resolveSource(file, json);
+  return;
 };
 
 /**
  * Create generators to recurse the next layer of dependencies.
  *
  * @param {Array} paths
- * @param {Object} out
  * @return {Array}
  * @api private
  */
 
-Duo.prototype.recurse = function (paths, out) {
+Duo.prototype.recurse = function (paths) {
   var includes = this.includes;
   var gens = [];
   var path;
   var file;
+  var root;
 
   for (var i = 0, path; path = paths[i++];) {
     if (includes[path]) continue;
     path = this.path(path);
+    root = this.findroot(path);
 
     file = this.file({
-      root: this.findroot(path),
+      root: root,
       path: path
     });
 
-    gens.push(this.dependencies(file, out));
+    gens.push(this.resolve(file));
   }
 
   return gens;
 };
 
 /**
- * Resolve a dependency by `dep`, from `file` with an `entry`.
+ * Resolve file from cache.
  *
- * @param {String} dep
  * @param {File} file
- * @param {File} entry
+ * @param {Object} json
+ * @return {Boolean}
+ * @api private
+ */
+
+Duo.prototype.resolvedLocally = function *(file, json) {
+  var isIncluded = json.include;
+  var isParsed = this.output[file.id];
+
+  // already visited
+  if (isParsed) {
+    debug('%s, already parsed. ignoring', file.id);
+    return true;
+  }
+
+  // included manually
+  if (isIncluded) {
+    this.output[file.id] = json;
+    return true;
+  }
+};
+
+/**
+ * Resolve file from cache.
+ *
+ * @param {File} file
+ * @param {Object} json
+ * @return {Boolean}
+ * @api private
+ */
+
+Duo.prototype.resolvedFromCache = function *(file, json) {
+  // check if the file has been modified
+  var isCached = file.mtime == json.mtime;
+  var isAsset = !rsupported.test(file.type);
+  if (!isCached) return;
+
+  debug('%s: has not been modified. skip parsing', file.id);
+  this.output[file.id] = json;
+  paths = values(json.deps);
+
+  // update the file
+  file.set(json);
+
+  // if a non-supported file type, bundle
+  if (isAsset) this.files.push(this.bundle(file.id));
+
+  // recurse the dependency's dependencies
+  var gens = this.recurse(paths);
+  yield this.parallel(gens);
+  return true;
+};
+
+/**
+ * Try resolving this `file` as an asset.
+ *
+ * @param {File} file
+ * @param {Object} json
+ * @return {Boolean}
+ * @api private
+ */
+
+Duo.prototype.resolveAsset = function *(file, json) {
+  // Not a supported file type, don't parse any farther
+  // But include in duo.json, for symlinking / copying
+  var isAsset = !rsupported.test(file.type);
+  if (!isAsset) return;
+  if (file.entry) throw error('%s: ".%s" not supported', file.id, file.type);
+  this.files.push(this.bundle(file.id));
+  delete file.attrs.src;
+  this.output[file.id] = file.json();
+  return true;
+};
+
+/**
+ * Finally, this must be a JavaScript, CSS, or some file 
+ * with potential dependencies that we can parse.
+ *
+ * @param {File} file
+ * @param {Object} json
+ * @return {Boolean}
+ * @api private
+ */
+
+Duo.prototype.resolveSource = function *(file, json) {
+  var deps = file.dependencies();
+  var depmap = {};
+
+  // logging
+  debug('%s deps: %j', file.id, deps);
+
+  // download and resolve the dependencies
+  for (var i = 0, dep; dep = deps[i++];) {
+    depmap[dep] = this.includes[dep]
+      ? dep 
+      : this.resolveDependency(dep, file);
+  }
+
+  // resolve dependencies from entry files,
+  // and remove unresolved deps
+  depmap = compact(yield depmap);
+  var paths = values(depmap);
+
+  // update the file with the resolved dependencies
+  file.set({ deps: depmap });
+  this.output[file.id] = file.json();
+
+  // recurse the dependency's dependencies
+  var gens = this.recurse(paths);
+  yield this.parallel(gens);
+};
+
+/**
+ * Given a dependency as defined in `@import` or `require`,
+ * figure out if it points to a local or remote file, and if
+ * that file is just an asset or an actual dependency.
+ * Then return that path.
+ *
+ * @param {String} dependencyPath
+ * @param {File} parent
  * @return {String}
  * @api private
  */
 
-Duo.prototype.dependency = function *(dep, file, entry) {
+Duo.prototype.resolveDependency = function *(dependencyPath, parent) {
+  var isHTTP = http(dependencyPath);
 
   // ignore http dependencies
-  if (http(dep)) {
-    debug('%s: ignoring dependency "%s"', file.id, dep)
+  if (isHTTP) {
+    debug('%s: ignoring dependency "%s"', parent.id, dependencyPath);
     return false;
   }
 
-  // local dependency
-  var local = yield this.resolve(dep, file, this.entry());
-  if (local) return relative(entry.root, local);
+  var local = yield this.resolveLocalPath(dependencyPath, parent);
+  if (local) return local;
+  var remote = yield this.resolveRemotePath(dependencyPath, parent);
+  if (remote) return remote;
+};
 
-  // remote dependency
-  var json = readJson(join(file.root, this.manifest()));
-  var pkg = this.package(dep, json);
-  if (!pkg) {
-    debug('%s: cannot resolve "%s"', file.id, dep);
+/**
+ * Resolve local path.
+ *
+ * @param {String} path
+ * @param {File} parent
+ * @return {String} relativePath
+ */
+
+Duo.prototype.resolveLocalPath = function *(dependencyPath, parent){
+  var path = yield this.resolveDependencyPath(dependencyPath, parent);
+  var entry = this.entry();
+  return path
+    ? relative(entry.root, path)
+    : false;
+};
+
+/**
+ * Resolve remote path.
+ *
+ * @param {String} path
+ * @param {File} parent
+ * @return {String|Boolean} relativePath
+ */
+
+Duo.prototype.resolveRemotePath = function *(dependencyPath, parent){
+  var entry = this.entry();
+  var dependency = parse(dependencyPath);
+  var dependencyPackage = yield this.fetchPackage(dependency, parent);
+  if (!dependencyPackage) {
+    debug('%s: cannot resolve "%s"', parent.id, dependencyPath);
     return false;
   }
-
-  // fetch the dependency
-  yield pkg.fetch();
 
   // path
-  var path = pkg.path(parse(dep).path || 'component.json');
-  var pkgfile = this.file({ root: pkg.path(), path: path });
-  var resolved = yield this.resolve(path, pkgfile, this.entry());
+  var manifestPath = dependency.path || this.manifest();
+  var dependencyManifestPath = dependencyPackage.path(manifestPath);
+  var dependencyManifestFile = this.file({
+    root: dependencyPackage.path(),
+    path: dependencyManifestPath
+  });
+
+  var dependencyEntryPath = yield this.resolveDependencyPath(
+    dependencyManifestPath,
+    dependencyManifestFile
+  );
 
   // logging
-  !resolved && debug('%s: cannot resolve "%s"', file.id, dep);
+  if (!dependencyEntryPath) {
+    debug('%s: cannot resolve "%s"', parent.id, dependencyPath);
+  }
 
   // return resolved or false
-  return resolved
-    ? relative(entry.root, resolved)
+  return dependencyEntryPath
+    ? relative(entry.root, dependencyEntryPath)
     : false;
 };
 
@@ -601,30 +686,37 @@ Duo.prototype.dependency = function *(dep, file, entry) {
  * @api private
  */
 
-Duo.prototype.resolve = function *(dep, file, entry) {
+Duo.prototype.resolveDependencyPath = function *(dep, file) {
+  var entry = this.entry();
+  var isManifest = this.manifest() == basename(dep);
   var ext = extension(dep) ? '' : '.' + entry.type;
+  var path = resolve(dirname(file.path), dep);
+  var isRelative = './' == dep.slice(0, 2);
+  var isParent = '..' == dep.slice(0, 2);
+  var isAbsolute = '/' == dep[0];
+  var isCSS = 'css' == entry.type;
   var ret;
 
-  if (this.manifest() == basename(dep)) {
+  if (isManifest) {
     // component
     var json = readJson(resolve(file.root, dep));
     var entrypoint = main(json, entry.type) || 'index.' + entry.type;
     ret = resolve(file.root, dirname(dep), entrypoint);
-  } else if ('/' == dep[0]) {
+  } else if (isAbsolute) {
     // absolute path (relative to app/component root)
     var relroot = this.findroot(file.path);
     ret = join(relroot, dep.replace(relroot, ''));
-  } else if ('..' == dep.slice(0, 2)) {
+  } else if (isParent) {
     // relative
-    ret = resolve(dirname(file.path), dep);
-  } else if ('./' == dep.slice(0, 2)) {
+    ret = path;
+  } else if (isRelative) {
     // relative
-    ret = resolve(dirname(file.path), dep);
-  } else if ('css' == entry.type && (yield relative(resolve(dirname(file.path), dep)))) {
+    ret = path;
+  } else if (isCSS && (yield relative(path))) {
     // hack to support relative paths without "./"
     // lots of for CSS urls with no "./" unfortunately
     // example "fonts/whatever"
-    ret = resolve(dirname(file.path), dep);
+    ret = path;
   }
 
   // not found
@@ -665,25 +757,25 @@ Duo.prototype.file = function (attrs) {
 };
 
 /**
- * Create a package from a `dep` with `json`.
+ * Fetch a package from a `dependency` defined inside `file`.
  *
- * @param {String} dep
- * @param {Object} json
+ * @param {Object} dependency
+ * @param {File} file Where this `dependency` was defined.
  * @return {Package|null}
  * @api private
  */
 
-Duo.prototype.package = function (dep, json) {
-  var gh = this.finddeps(parse(dep), json);
-  if (!gh) return null;
+Duo.prototype.fetchPackage = function *(dependency, file) {
+  var manifest = this.loadManifest(file);
+  dependency = this.normalizeDependency(dependency, manifest);
+  if (!dependency) return null;
+  var installPath = this.installPath();
+  var token = this.token();
 
   // initialize the package
-  var pkg = Package(gh.package, gh.ref)
-    .directory(this.installPath());
-
-  // pass the token in, if we have one
-  var token = this.token();
-  token && pkg.token(token);
+  var pkg = Package(dependency.package, dependency.ref);
+  pkg.directory(installPath);
+  if (token) pkg.token(token);
 
   // forward package events to duo
   pkg
@@ -692,51 +784,77 @@ Duo.prototype.package = function (dep, json) {
     .once('resolve', this.forward('resolve'))
     .once('install', this.forward('install'));
 
+  // fetch the dependency
+  yield pkg.fetch();
+
   return pkg;
 };
 
 /**
  * Find the repo in the `jsons`'s dependencies.
  *
- * @param {Object} gh
- * @param {Object} json
+ * @param {Object} obj
+ * @param {Object} manifest
  * @return {Object}
  * @api private
  */
 
-Duo.prototype.finddeps = function(gh, json) {
-  if (gh.user && gh.repo && gh.ref) {
-    gh.package = gh.user + '/' + gh.repo;
-    return gh;
+Duo.prototype.normalizeDependency = function(obj, manifest) {
+  // if we get `require('user/repo@ref'), then use that.
+
+  if (obj.user && obj.repo && obj.ref) {
+    obj.package = obj.user + '/' + obj.repo;
+    return obj;
   }
 
   var dev = this.development();
-  var deps = json.dependencies || {};
+  var deps = manifest.dependencies || {};
   var rext = '([\.][a-z]+)?';
 
-  if (dev && json == this.json) {
-    deps = extend(deps, json.development || {});
+  if (dev && manifest == this.json) {
+    deps = extend(deps, manifest.development || {});
   }
 
-  var re = gh.user
-    ? new RegExp('^' + gh.user + '[\\/:]' + gh.repo + rext + '$', 'i')
-    : new RegExp('([\\/:])?' + gh.repo + rext + '$', 'i');
+  var re = obj.user
+    ? new RegExp('^' + obj.user + '[\\/:]' + obj.repo + rext + '$', 'i')
+    : new RegExp('([\\/:])?' + obj.repo + rext + '$', 'i');
+
+  // go throuobj each of the dependencies in component.json,
+  // and try to find one that matches the string.
 
   for (var dep in deps) {
     if (re.test(dep) || re.test(dep.replace('/', '-'))) {
-      gh.package = dep;
-      gh.ref = deps[dep];
-      return gh;
+      obj.package = dep;
+      obj.ref = deps[dep];
+      return obj;
     }
   }
 
-  if (gh.user && gh.repo) {
-    gh.package = gh.user + '/' + gh.repo;
-    gh.ref = '*';
-    return gh;
+  // if the obj that was originally passed in
+  // was in the form `require('user/repo')`, then we can use that.
+
+  if (obj.user && obj.repo) {
+    obj.package = obj.user + '/' + obj.repo;
+    obj.ref = '*';
+    return obj;
   }
 
   return null;
+};
+
+/**
+ * Compile dependencies to their most optimal form.
+ *
+ * @api private
+ */
+
+Duo.prototype.compileDependencies = function () {
+  var output = this.output;
+  for (var id in output) {
+    var json = output[id];
+    var deps = json.deps;
+    // TODO: here's where the code will optimize/adjust the dependencies
+  }
 };
 
 /**
@@ -827,6 +945,20 @@ Duo.prototype.forward = function (name) {
     duo.emit.apply(duo, args);
     return ctx;
   };
+};
+
+/**
+ * Load component.json manifest relative to `file`.
+ *
+ * @param {File} file
+ * @return {Object} json
+ * @api private
+ */
+
+Duo.prototype.loadManifest = function(file){
+  var name = this.manifest();
+  var manifestPath = join(file.root, name);
+  return readJson(manifestPath);
 };
 
 /**


### PR DESCRIPTION
@MatthewMueller @ianstormtaylor this is what the previous 4 PRs look like squashed. I have also added 1 more method, `compileDependencies`, which will hopefully be a place where we can run through the dependencies one last time and adjust the `*` (so we can fix that one issue) and perhaps work toward the versioning stuff we were mapping out here https://github.com/duojs/duo/issues/296.

The main thing about keeping the commits separate (like in the previous PRs) is you can see how the changes progress, whereas the final thing seems like a lot has changed since methods were renamed and such haha.

After this or the first 4 PRs get rejected/approved/merged, I can implement the pieces @MatthewMueller suggested to change:
- [x] move this out of the top to prevent performance hit `var isRelativeCSS = 'css' == entry.type && (yield relative(path));`
- [ ] refactor the `isAsset = !rsupported.test(file.type);` snippets. if we can, maybe don't even load the asset into memory as well
- [x] revert this loop before things are merged: https://github.com/duojs/duo/commit/ac14a63362f4122b23c1f9df86f0df1d0eee803b#commitcomment-7756794
