### PR TITLE
package.json: Upgrade gnode to 0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "extend.js": "0.0.1",
     "file-deps": "0.0.5",
     "get-stdin": "~1.0.0",
-    "gnode": "0.0.8",
+    "gnode": "0.1.0",
     "json-mask": "^0.3.1",
     "language-classifier": "0.0.1",
     "max-component": "~1.0.0",


### PR DESCRIPTION
gnode's upstream dep regenerator broke its api.  this patch fixes
duo(1) when using node 0.10.

closes #312.
