### PR TITLE
Adding capability to bypass cache

### DIFF
--- a/bin/_duo
+++ b/bin/_duo
@@ -52,6 +52,7 @@ var program = new Command('duo')
   .version(pkg.version)
   .usage('[options] command|[file, ...] [out]')
   .option('-c, --copy', 'opt to copy files instead of symlink', false)
+  .option('-C, --no-cache', 'enable or disable the cache during build', true)
   .option('-d, --development', 'include development dependencies.', false)
   .option('-g, --global <name>', 'expose entry as a global <name>', null)
   .option('-o, --output <dir>', 'set the output directory, defaulted to build/', null)
@@ -298,7 +299,8 @@ function create(entry) {
   var duo = Duo(root)
     .entry(resolve(program.root || cwd, entry))
     .development(!! program.development)
-    .copy(program.copy);
+    .copy(program.copy)
+    .cache(program.cache);
 
   // global
   program.global && duo.global(program.global);

--- a/lib/duo.js
+++ b/lib/duo.js
@@ -72,6 +72,7 @@ function Duo(root) {
   this.copy(false);
   this.development(false);
   this.concurrency(50);
+  this.cache(true);
 
   this.files = [];
   this.mapping = {};
@@ -214,6 +215,20 @@ Duo.prototype.copy = function (value) {
 Duo.prototype.concurrency = function (value) {
   if (!arguments.length) return this._concurrency;
   this._concurrency = value;
+  return this;
+};
+
+/**
+ * Get or set whether the cache should be used
+ *
+ * @param {Boolean} value (optional)
+ * @return {Duo|Boolean}
+ * @api public
+ */
+
+Duo.prototype.cache = function (value) {
+  if (!arguments.length) return this._cache;
+  this._cache = value;
   return this;
 };
 
@@ -387,7 +402,7 @@ Duo.prototype.run = unyield(function *() {
     .use(stoj());
 
   // 1) Try to load duo.json mapping
-  this.mapping = yield mapping.read();
+  if (this.cache()) this.mapping = yield mapping.read();
 
   // ensure that the entry exists
   if (!(yield file.exists())) {
@@ -460,7 +475,7 @@ Duo.prototype.dependencies = function *(file, out) {
   }
 
   // check if the file has been modified
-  if (isCached) {
+  if (this.cache() && isCached) {
     debug('%s: has not been modified. skip parsing', file.id);
     out[file.id] = json;
     paths = values(json.deps);

--- a/test/api.js
+++ b/test/api.js
@@ -53,6 +53,7 @@ describe('Duo API', function () {
     assert.equal(duo._copy, false);
     assert.equal(duo._development, false);
     assert.equal(duo._concurrency, 50);
+    assert.equal(duo._cache, true);
   });
 
   describe('.entry()', function () {
@@ -184,11 +185,28 @@ describe('Duo API', function () {
     });
   });
 
-  describe('.concurrency(name)', function () {
+  describe('.concurrency(value)', function () {
     it('should set the download concurrency value', function () {
       var duo = Duo(__dirname);
       duo.concurrency(1);
       assert.equal(duo.concurrency(), 1);
+    });
+  });
+
+  describe('.cache()', function () {
+    it('should get the cache flag', function () {
+      var duo = Duo(__dirname);
+      assert.equal(duo.cache(), true);
+    });
+  });
+
+  describe('.cache(value)', function () {
+    it('should set the cache flag', function () {
+      var duo = Duo(__dirname);
+      duo.cache(true);
+      assert.equal(duo.cache(), true);
+      duo.cache(false);
+      assert.equal(duo.cache(), false);
     });
   });
 
@@ -463,6 +481,24 @@ describe('Duo API', function () {
         var js = yield duo.run();
         var ctx = evaluate(js);
         assert('global module' == ctx['global-module']);
+      });
+    });
+
+    describe('with .cache(false)', function () {
+      it('should have an empty mapping', function *() {
+        var duo = build('idempotent').cache(false);
+        yield duo.run();
+        assert.deepEqual(duo.mapping, {});
+      });
+
+      it('should not update the mapping', function *() {
+        yield build('idempotent').cache(false).run();
+
+        try {
+          var json = yield mapping('idempotent');
+        } catch (e) {
+          assert.equal(e.code, "ENOENT");
+        }
       });
     });
 


### PR DESCRIPTION
This is related to #327, but is not a complete solution.

This adds `duo.cache([value])` which gets/sets a flag determining whether or not to use the cache. (it only prevents reading the `duo.json`, but it will still write) To round out #327, we could use this to flip off the cache on certain conditions.
