### PR TITLE
Getting the CLI to acknowledge the output flag

### DIFF
--- a/bin/_duo
+++ b/bin/_duo
@@ -224,7 +224,7 @@ function input() {
  */
 
 function build(entries) {
-  outdir && entries.pop();
+  outdir && !program.output && entries.pop();
   var len = entries.length;
 
   return !len

--- a/test/cli.js
+++ b/test/cli.js
@@ -293,6 +293,15 @@ describe('Duo CLI', function () {
     });
   });
 
+  describe('duo --output <dir>', function () {
+    it('should change to another output directory', function *() {
+      var out = yield exec('duo --output out *.js', 'entries');
+      assert(exists('entries/out/index.js'));
+      assert(exists('entries/out/admin.js'));
+      rm('entries/out');
+    });
+  });
+
   describe('duo ls', function () {
     beforeEach(function *() {
       yield exec('duo -q index.js > build.js', 'cli-duo-ls');


### PR DESCRIPTION
Currently, `--output` is not respected by the CLI, so I've added support for it. :)
