### PR TITLE
fix duo.resolve()

### DIFF
--- a/lib/duo.js
+++ b/lib/duo.js
@@ -667,7 +667,7 @@ Duo.prototype.dependency = function *(dep, file, entry) {
 
 Duo.prototype.resolve = function *(dep, file, entry) {
   var isManifest = this.manifest() == basename(dep);
-  var ext = extension(dep) ? '' : '.' + entry.type;
+  var ext = isManifest || extension(dep) === entry.type ? '' : '.' + entry.type;
   var path = resolve(dirname(file.path), dep);
   var isRelative = './' == dep.slice(0, 2);
   var isParent = '..' == dep.slice(0, 2);


### PR DESCRIPTION
If path is not a manifest file and it has extension name and it's extension name is not equal to entry's extension name, then duo will resolve wrong path.

``` javascript
require('./module.test');

// should equal to

require('./module.test.js');
```
