### PR TITLE
package: Update debug

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "component-clone": "^0.2.2",
     "concat-stream": "^1.4.6",
     "cp": "^0.1.1",
-    "debug": "^0.7.4",
+    "debug": "^2.0.0",
     "delegates": "0.0.3",
     "duo-css-compat": "0.0.3",
     "duo-main": "^0.0.3",


### PR DESCRIPTION
debug@2 uses `stderr` again, so may as well use the latest version.
