### PR TITLE
Add "cache" flag to API documentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -42,7 +42,7 @@ Set Duo to development mode. This will include `development` dependencies in you
 duo.development(true);
 ```
 
-### 'duo.cache(boolean)'
+### `duo.cache(boolean)`
 
 Turn caching on or off.  With caching turned on, plugin transformations will not be called unless the file changes. Defaults to true.
 


### PR DESCRIPTION
It might help to add the cache method to the API documentation.  When testing custom plugins, it's reasonable you'd want to turn caching off (rather than changing files every time).
