### PR TITLE
adding way to check if something has already been included

### DIFF
--- a/lib/duo.js
+++ b/lib/duo.js
@@ -348,6 +348,18 @@ Duo.prototype.include = function (name, src) {
 };
 
 /**
+ * Check the includes hash for the given name
+ *
+ * @param {String} name
+ * @return {Boolean}
+ * @api public
+ */
+
+Duo.prototype.included = function (name) {
+  return name in this.includes;
+};
+
+/**
  * Write the built source to a `path`, which defaults
  * to the same name as the entry file's name.
  *

--- a/lib/file.js
+++ b/lib/file.js
@@ -75,7 +75,8 @@ delegate(File.prototype, 'attrs')
 
 delegate(File.prototype, 'duo')
   .getter('plugins')
-  .method('include');
+  .method('include')
+  .method('included');
 
 /**
  * Parse the dependencies in `this.src`.

--- a/test/api.js
+++ b/test/api.js
@@ -261,6 +261,23 @@ describe('Duo API', function () {
     });
   });
 
+  describe('.include(name, src)', function () {
+    it('should add the specified module to the includes hash', function () {
+      var duo = build('includes');
+      duo.include('some-include', 'module.exports = "a"');
+      assert('some-include' in duo.includes);
+    });
+  });
+
+  describe('.included(name)', function () {
+    it('should tell us if something has already been included', function () {
+      var duo = build('includes');
+      assert(!duo.included('some-include'));
+      duo.include('some-include', 'module.exports = "a"');
+      assert(duo.included('some-include'));
+    });
+  });
+
   describe('.run([fn])', function () {
     it('should ignore runs without an entry or source', function *() {
       var js = yield Duo(__dirname).run();


### PR DESCRIPTION
When writing plugins, I thought it would be convenient for duo to add a little API for checking if something has already been included. This has the benefit of simplifying plugins, since they don't need their own boolean flag to make sure they don't include the same thing more than once.

This could also be useful for plugins that may want to inject something that another plugin may want to inject. For example, I'm using a module that generally works only for node, but only uses `path`, so I figured I would probably drop in the browserify port. With that in mind, I'm sure more than 1 plugin will want to do this.

``` js
// before
module.exports = function () {
  var included = false;
  return function *(file) {
    // do stuff
    if (!included) file.include("path", "...");
    // do more stuff
  };
};

// after
module.exports = function () {
  return function *(file) {
    // do stuff
    if (!file.included('path')) file.include("path", "...");
    // do more stuff
  };
};
```
