### PR TITLE
Updated isAbsolute test to be cross platform

### DIFF
--- a/lib/duo.js
+++ b/lib/duo.js
@@ -707,7 +707,7 @@ Duo.prototype.resolve = function *(dep, file, entry) {
   var path = resolve(dirname(file.path), dep);
   var isRelative = './' == dep.slice(0, 2);
   var isParent = '..' == dep.slice(0, 2);
-  var isAbsolute = '/' == dep[0];
+  var isAbsolute = resolve(dep) === dep;
   var ret;
 
   if (isManifest) {


### PR DESCRIPTION
Currently the code determines whether a path is absolute by checking that the first character is a forward slash.  Given that some people may be building dependencies on a Windows OS, I have updated the test.
