### PR TITLE
Improving plugin usage in CLI

### DIFF
--- a/bin/_duo
+++ b/bin/_duo
@@ -316,21 +316,20 @@ function create(entry) {
     duo.on('installing', log('installing'));
   }
 
+  // events
+  if (!quiet) {
+    duo.on('plugin', log('using'));
+    duo.on('install', log('installed'));
+    duo.on('running', log('building'));
+    duo.on('run', log('built'));
+  }
+
   // output dir
   outdir && duo.buildTo(outdir);
   program.out && duo.buildTo(program.out);
 
   // use plugins
-  plugins.forEach(function (plugin) {
-    duo.use(plugin);
-  });
-
-  // events
-  if (!quiet) {
-    duo.on('install', log('installed'));
-    duo.on('running', log('building'));
-    duo.on('run', log('built'));
-  }
+  plugins.forEach(duo.use, duo);
 
   return duo;
 }
@@ -457,12 +456,11 @@ function use(plugins) {
       else if (exists(npm)) mod = require(npm);
       else mod = require(cwd);
 
-      !quiet && logger.using(plugin);
-      return mod();
+      return Array.isArray(mod) ? mod : mod();
     } catch (e) {
       error(e);
     }
-  });
+  }, []);
 }
 
 /**

--- a/lib/duo.js
+++ b/lib/duo.js
@@ -279,10 +279,17 @@ Duo.prototype.buildTo = function (path) {
  */
 
 Duo.prototype.use = function (fn) {
-  if (~this.plugins.fns.indexOf(fn)) return this;
-  debug('using plugin: %s', fn.name || fn.toString());
-  this.plugins.use(fn);
-  return this;
+  if (Array.isArray(fn)) {
+    fn.forEach(this.use, this);
+    return this;
+  } else {
+    if (~this.plugins.fns.indexOf(fn)) return this;
+    var name = fn.name || '(anonymous)';
+    this.emit('plugin', name);
+    debug('using plugin: %s', name);
+    this.plugins.use(fn);
+    return this;
+  }
 };
 
 /**

--- a/test/cli.js
+++ b/test/cli.js
@@ -303,24 +303,24 @@ describe('Duo CLI', function () {
     it('should allow npm modules', function *() {
       this.timeout(10000);
       var out = yield exec('duo --use duo-jade index.js', 'plugins');
-      assert(contains(out.stderr, 'using : duo-jade'));
+      assert(contains(out.stderr, 'using : jade'));
     });
 
     it('should allow regular js files', function *() {
       var out = yield exec('duo --use plugin.js index.js', 'plugins');
-      assert(contains(out.stderr, 'using : plugin.js'));
+      assert(contains(out.stderr, 'using : plugin'));
     });
 
     it('should allow multiple plugins', function *() {
       var out = yield exec('duo --use duo-jade,plugin.js index.js', 'plugins');
-      assert(contains(out.stderr, 'using : duo-jade'));
-      assert(contains(out.stderr, 'using : plugin.js'));
+      assert(contains(out.stderr, 'using : jade'));
+      assert(contains(out.stderr, 'using : plugin'));
     });
 
     it('should allow multiple calls to --use', function *() {
       var out = yield exec('duo --use duo-jade --use plugin.js index.js', 'plugins');
-      assert(contains(out.stderr, 'using : duo-jade'));
-      assert(contains(out.stderr, 'using : plugin.js'));
+      assert(contains(out.stderr, 'using : jade'));
+      assert(contains(out.stderr, 'using : plugin'));
     });
 
     it('should bomb if the plugin does not exist', function *() {
@@ -332,15 +332,20 @@ describe('Duo CLI', function () {
       var out = yield exec('duo --use plugin index.js', 'plugins');
       assert(contains(out.stderr, 'using : plugin'));
     });
-  });
 
-  describe('duo --use <plugin>', function () {
+    it('should allow an array of plugins', function *() {
+      var out = yield exec('duo --use plugins index.js', 'plugins');
+      assert(contains(out.stderr, 'using : plugin1'));
+      assert(contains(out.stderr, 'using : plugin2'));
+      assert(contains(out.stderr, 'using : (anonymous)'));
+    });
+
     it('should allow npm modules from the working directory', function *() {
       var cwd = join(__dirname, '..');
       var src = join(__dirname, 'fixtures', 'plugins');
       var cmd = join(__dirname, '..', 'bin', 'duo');
       var out = yield execute(cmd + ' -r ' + src + ' --use duo-jade index.js', { cwd: cwd });
-      assert(contains(out.stderr, 'using : duo-jade'));
+      assert(contains(out.stderr, 'using : jade'));
     });
   });
 

--- a/test/fixtures/plugins/plugin.js
+++ b/test/fixtures/plugins/plugin.js
@@ -1,5 +1,5 @@
 module.exports = function () {
-    return function () {
+    return function plugin() {
         console.log("plugin");
     };
 };

--- a/test/fixtures/plugins/plugins.js
+++ b/test/fixtures/plugins/plugins.js
@@ -1,0 +1,13 @@
+module.exports = [
+  function plugin1(file) {
+    // plugin 1
+  },
+
+  function plugin2(file) {
+    // plugin 2
+  },
+
+  function (file) {
+    // plugin 3 (anonymous)
+  }
+];


### PR DESCRIPTION
## Multiple `--use` flags

This adds the ability to use `--use` multiple times, while still allowing comma-separated lists for backwards-compatibility.

``` sh
# this
% duo --use duo-handlebars,duo-6to5,duo-myth ...

# can now be expressed as
% duo --use duo-handlebars --use duo-6to5 --use duo-myth ...

# or even
% duo --use duo-handlebars,duo-6to5 --use duo-myth
```
## Allow leaving off the `.js` for local modules

``` sh
# this
% duo --use plugin.js

# can now be expressed as
% duo --use plugin
```
## Exporting an `Array` of plugins

This last change allows the inclusion of many plugins with custom config much more elegantly. For example:

**plugins.js**

``` js
var es6 = require('duo-6to5');
var hbs = require('duo-handlebars');
var myth = require('duo-myth');

module.exports = [
  hbs(),
  myth({
    customMedia: false,
    calc: false
  }),
  es6({
    onlyLocals: true
  })
];
```

``` sh
% duo --use plugins index.{js,css}
```

``` js
var plugins = require('./plugins');

duo(...)
  .use(plugins)
  // ...
```

I think this is a solid solution to the problem of configuring plugins, which has come up several times before. This would normalize the behavior in such a way that both the API and CLI can effectively take the same argument and do the same thing. I think this pattern is really easy to understand and requires no new syntax or knowledge for the average node dev.
