### PR TITLE
Removing some magic from the CLI

### DIFF
--- a/bin/_duo
+++ b/bin/_duo
@@ -17,6 +17,7 @@ var Watch = require('duo-watch');
 var join = require('path').join;
 var spawn = require('win-fork');
 var pkg = require('../package');
+var glob = require('glob').sync;
 var Batch = require('batch');
 var stdout = process.stdout;
 var cwd = process.cwd();
@@ -62,6 +63,7 @@ var program = new Command('duo')
   .option('-v, --verbose', 'show as much logs as possible', false)
   .option('-w, --watch', 'watch for changes and rebuild', false)
   .option('-s, --standalone <standalone>', 'outputs standalone javascript umd <standalone>', '')
+  .option('-S, --stdout', 'outputs build to stdout', false)
   .parse(process.argv);
 
 /**
@@ -71,20 +73,17 @@ var program = new Command('duo')
 program.on('--help', function () {
   console.log('  Usage:');
   console.log();
-  console.log('  # build in.js to out.js');
-  console.log('  $ duo in.js > out.js');
-  console.log();
-  console.log('  # build in.css to out.css');
-  console.log('  $ duo in.css > out.css');
-  console.log();
-  console.log('  # build all files to duo.assets() (default: build/)');
+  console.log('  # build all files to build/');
   console.log('  $ duo *.{js,css}');
   console.log();
   console.log('  # build all files to the out/ folder');
-  console.log('  $ duo *.{js,css} out');
+  console.log('  $ duo --output out/ *.{js,css}');
   console.log();
   console.log('  # build from stdin and output out.css');
   console.log('  $ duo < in.css > out.css');
+  console.log();
+  console.log('  # build to out.js using stdout');
+  console.log('  $ duo --stdout in.js > out.js');
   console.log();
   console.log('  # build using a plugin');
   console.log('  $ npm install duo-whitespace');
@@ -141,7 +140,7 @@ var root = findroot(program.root);
  * Asset path.
  */
 
-var outdir = program.output || assets(program.args);
+var outdir = program.output;
 
 /**
  * Watching.
@@ -154,6 +153,15 @@ var watching = false;
  */
 
 var plugins = use(program.use);
+
+/**
+ * Stdout.
+ */
+
+if (program.stdout && program.args.length > 1) {
+  logger.error('cannot use stdout with multiple entries');
+  return;
+}
 
 /**
  * Custom executable.
@@ -194,7 +202,8 @@ if (command && !isFile(command)) {
  * Actions.
  */
 
-if (command) build(program.args.filter(globs));
+if (program.stdout && command) print(command);
+else if (program.args.length) write(entries(program.args));
 else if (!process.stdin.isTTY) input();
 else program.help();
 
@@ -215,23 +224,6 @@ function input() {
       process.exit(0);
     });
   });
-}
-
-/**
- * Build the entries.
- *
- * @param {Array} entries
- */
-
-function build(entries) {
-  outdir && !program.output && entries.pop();
-  var len = entries.length;
-
-  return !len
-    ? program.help()
-    : 1 == len && !outdir
-    ? print(entries[0])
-    : write(entries);
 }
 
 /**
@@ -260,7 +252,7 @@ function print(entry) {
  */
 
 function write(entries) {
-  entries = 'string' == typeof entries ? [entries] : entries;
+  if ('string' == typeof entries) entries = [entries];
 
   var batch = new Batch;
   var push = batch.push.bind(batch);
@@ -353,7 +345,7 @@ function watch(action) {
  * @return {Function}
  */
 
-function log (event) {
+function log(event) {
   return function (pkg) {
     pkg = pkg.slug ? pkg.slug() : pkg;
     pkg = 'source.' + (program.type || 'js') == pkg ? 'from stdin' : pkg;
@@ -395,20 +387,6 @@ function findroot(root) {
 }
 
 /**
- * Check if `entries` contains an asset path.
- *
- * @param {Array} entries
- * @return {String|Boolean}
- */
-
-function assets(entries) {
-  if (!entries.length) return false;
-  var len = entries.length;
-  var last = entries[len - 1];
-  return !isFile(last) && last;
-}
-
-/**
  * Filter out unexpanded globs.
  *
  * @param {String} entry
@@ -437,7 +415,34 @@ function isFile(path) {
 }
 
 /**
- * Resolve each plugin from the string provided by the user.
+ * Simple hueristic to check if `path` is a directory.
+ *
+ * @param {String} path
+ * @return {Boolean}
+ */
+
+function isDir(path) {
+  try {
+    return stat(path).isDirectory();
+  } catch (e) {
+    return false;
+  }
+}
+
+/**
+ * Gets a list of all files within a directory recursively (and synchronously)
+ *
+ * @param {String} path
+ * @return {Array:String}
+ */
+
+function listFiles(path, pattern) {
+  var opts = { cwd: root, nodir: true };
+  return glob(pattern || '**/*', opts);
+}
+
+/**
+ * Retrieve an array of plugins from `--use`.
  *
  * @param {Array:String} plugins
  * @return {Array:Function}
@@ -473,6 +478,26 @@ function collect(val, memo) {
   });
 
   return memo;
+}
+
+/**
+ * Normalize entries list.
+ *
+ *  - expand globs
+ *  - expand directories into list of all nested files
+ *
+ * @param {Array:String}
+ * @return {Array:String}
+ */
+
+function entries(list) {
+  return list.filter(globs).reduce(function (memo, entry) {
+    if (isDir(join(root, entry))) {
+      return memo.concat(listFiles(entry));
+    } else {
+      return memo.concat(entry);
+    }
+  }, []);
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "extend.js": "0.0.1",
     "file-deps": "^0.0.7",
     "get-stdin": "~1.0.0",
+    "glob": "^4.3.1",
     "gnode": "0.1.0",
     "json-mask": "^0.3.1",
     "language-classifier": "0.0.1",


### PR DESCRIPTION
This PR aims to simplify the CLI as described in #400:
- no longer automatically piping to stdout for a single entry
  - when using `stdin`, using `stdout` is implied and still works as before
  - the `--stdout` flag has been added to specify `stdout`
- removing the implicit 'output' dir as the last argument
  - the already available `--output` flag should now always be used
- expanding folders via `glob` into a list of files (arguably magic, but predictable)

Overall, I think this will be a huge win for simplicity and predictability on the part of the CLI, while still retaining stdout capabilities.

Not only that, but it adds handling for directories of assets. I think this should be the preferred approach for addressing things like #171 without needing to get involved with parsing HTML/Jade/<any other templating language> which would be a huge pain in sooooooo many ways. (not to mention brittle) This will also be the first step towards becoming a true asset pipeline, where plugins can freely transform assets in addition to source code. :)

Really wanting some feedback on this one, as this is not _entirely_ backwards-compatible.

/cc @MatthewMueller @stephenmathieson 
