### PR TITLE
bin: Parse credentials from `~/.netrc` and propagate to `Duo#token()`

### DIFF
--- a/bin/_duo
+++ b/bin/_duo
@@ -12,6 +12,7 @@ var dirname = require('path').dirname;
 var mkdirp = require('mkdirp').sync;
 var Logger = require('stream-log');
 var stat = require('fs').statSync;
+var netrc = require('node-netrc');
 var stdin = require('get-stdin');
 var Watch = require('duo-watch');
 var join = require('path').join;
@@ -43,6 +44,14 @@ logger.type('error', '31m', function () {
   logger.end();
   process.exit(1);
 });
+
+/**
+ * GitHub credentials.
+ */
+
+var auth = netrc('api.github.com') || {
+  password: process.env.GH_TOKEN
+};
 
 /**
  * Program.
@@ -276,7 +285,7 @@ function write(entries) {
   function multiple(entry) {
     return function (done) {
       create(entry).write(done);
-    }
+    };
   }
 }
 
@@ -292,6 +301,7 @@ function create(entry) {
     .entry(resolve(program.root || cwd, entry))
     .development(!! program.development)
     .copy(program.copy)
+    .token(auth.password)
     .cache(program.cache);
 
   // standalone
@@ -350,7 +360,7 @@ function log(event) {
     pkg = pkg.slug ? pkg.slug() : pkg;
     pkg = 'source.' + (program.type || 'js') == pkg ? 'from stdin' : pkg;
     logger[event](pkg);
-  }
+  };
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "language-classifier": "0.0.1",
     "max-component": "~1.0.0",
     "mkdirp": "^0.5.0",
+    "node-netrc": "0.0.1",
     "step.js": "~2.0.2",
     "stream-log": "0.1.0",
     "thunkify": "~2.1.1",


### PR DESCRIPTION
Once a new version of `duo-package` has been released (containing duojs/package@4a0007a), this patch will fix all `~/.netrc` compatibility-related issues.

Ref. duojs/package#50.