### PR TITLE
Fixing case where duo treated folder arguments as sub-commands

### DIFF
--- a/bin/_duo
+++ b/bin/_duo
@@ -9,6 +9,7 @@ var Command = require('commander').Command;
 var exists = require('fs').existsSync;
 var resolve = require('path').resolve;
 var dirname = require('path').dirname;
+var extname = require('path').extname;
 var mkdirp = require('mkdirp').sync;
 var Logger = require('stream-log');
 var stat = require('fs').statSync;
@@ -164,10 +165,12 @@ if (program.stdout && program.args.length > 1) {
 }
 
 /**
- * Custom executable.
+ * Use a custom executable when there is at least 1 argument (ie: "command")
+ * that does not appear to have a file extension and does not correspond to
+ * something in the filesystem.
  */
 
-if (command && !isFile(command)) {
+if (command && !extname(command) && !exists(command)) {
   var args = process.argv.slice(3);
 
   // find executable
@@ -395,23 +398,6 @@ function findroot(root) {
 
 function globs(path) {
   return !/\*/.test(path);
-}
-
-/**
- * Simple hueristic to check if `path` is a file.
- *
- * @param {String} path
- * @return {Boolean}
- */
-
-function isFile(path) {
-  if (/^[^\s]+\.\w*$/g.test(path)) return true;
-
-  try {
-    return stat(path).isFile();
-  } catch (e) {
-    return false;
-  }
 }
 
 /**

--- a/test/cli.js
+++ b/test/cli.js
@@ -149,6 +149,18 @@ describe('Duo CLI', function () {
       assert(exists('assets/build/svg/logo-white.svg'));
       assert(exists('assets/build/svg/logo-black.svg'));
     });
+
+    it('should recursively copy directories even if they are the only argument', function *() {
+      var out = yield exec('duo svg', 'assets');
+      if (out.error) throw out.error;
+      assert(contains(out.stderr, 'building : svg/logo-white.svg'));
+      assert(contains(out.stderr, 'built : svg/logo-white.svg'));
+      assert(contains(out.stderr, 'building : svg/logo-black.svg'));
+      assert(contains(out.stderr, 'built : svg/logo-black.svg'));
+      assert(exists('assets/build/duo.png'));
+      assert(exists('assets/build/svg/logo-white.svg'));
+      assert(exists('assets/build/svg/logo-black.svg'));
+    });
   });
 
   describe('duo < in.js', function () {


### PR DESCRIPTION
When the first argument passed is a folder-name, duo was trying to treat it like a subcommand, and then would fail. For example:

```sh
$ duo public

    error : duo-public(1) does not exist
```

I've changed the sub-command check to handle this new use-case as well, where that conditional looks like `command && !extname(command) && !exists(command)`

I opted for the extname check to avoid a sync call to the filesystem if we were looking at something like `index.js`, but if we wanted to support `.` in sub-command names, this will have to change to something like: `command && !isFile(command) && !isDir(command)`

The point is, all the tests pass :)