### PR TITLE
Handle syntax errors in manifests more gracefully

### DIFF
--- a/bin/_duo
+++ b/bin/_duo
@@ -6,6 +6,7 @@
 
 var detect = require('language-classifier');
 var Command = require('commander').Command;
+var relative = require('path').relative;
 var exists = require('fs').existsSync;
 var resolve = require('path').resolve;
 var dirname = require('path').dirname;
@@ -362,8 +363,13 @@ function log(event) {
 
 function error(err) {
   err = 'string' == typeof err ? new Error(err) : err;
-  logger.error(err.stack);
-  logger.end();
+  if (err instanceof SyntaxError && err.fileName) {
+    var msg = err.message;
+    var file = relative(process.cwd(), err.fileName);
+    logger.error('Syntax error:', msg, 'in:', file);
+  } else {
+    logger.error(err.stack);
+  }
 }
 
 /**

--- a/lib/duo.js
+++ b/lib/duo.js
@@ -1137,9 +1137,28 @@ function readJson(path) {
   try {
     return require(path);
   } catch(e) {
+    if (e instanceof SyntaxError) throw jsonSyntaxError(e, path);
     return {};
   }
 }
+
+/**
+* Processes a SyntaxError trapped by readJson and creates a more user-friendly
+* error message. (and adds the `fileName` property)
+*
+* @param {SyntaxError} err
+* @returns {SyntaxError}
+*/
+
+function jsonSyntaxError(err, path) {
+  var msg = err.message.split(': ')[1];
+
+  err.message = msg;
+  err.fileName = path;
+
+  return err;
+}
+
 
 /**
  * Reads an include file and parses for dependencies

--- a/test/api.js
+++ b/test/api.js
@@ -361,6 +361,23 @@ describe('Duo API', function () {
       assert.equal(ctx, 'function');
     });
 
+    it('should fail when manifest has a syntax error', function *() {
+      try {
+        yield build('manifest-syntax-err').run();
+      } catch (e) {
+        assert(e instanceof SyntaxError);
+      }
+    });
+
+    it('should decorate the SyntaxError object', function *() {
+      try {
+        yield build('manifest-syntax-err').run();
+      } catch (e) {
+        assert.equal(e.message, 'Unexpected token }');
+        assert.equal(e.fileName, path('manifest-syntax-err/component.json'));
+      }
+    });
+
     it('should be idempotent', function *() {
       var a = yield build('idempotent').run();
       var b = yield build('idempotent').run();

--- a/test/api.js
+++ b/test/api.js
@@ -363,19 +363,21 @@ describe('Duo API', function () {
 
     it('should fail when manifest has a syntax error', function *() {
       try {
-        yield build('manifest-syntax-err').run();
+        var success = yield build('manifest-syntax-err').run();
       } catch (e) {
         assert(e instanceof SyntaxError);
       }
+      assert(!success);
     });
 
     it('should decorate the SyntaxError object', function *() {
       try {
-        yield build('manifest-syntax-err').run();
+        var success = yield build('manifest-syntax-err').run();
       } catch (e) {
         assert.equal(e.message, 'Unexpected token }');
         assert.equal(e.fileName, path('manifest-syntax-err/component.json'));
       }
+      assert(!success);
     });
 
     it('should be idempotent', function *() {

--- a/test/fixtures/manifest-syntax-err/component.json
+++ b/test/fixtures/manifest-syntax-err/component.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "component/type": "*"
+  }
+
+  ,
+}

--- a/test/fixtures/manifest-syntax-err/index.js
+++ b/test/fixtures/manifest-syntax-err/index.js
@@ -1,0 +1,2 @@
+
+module.exports = require('type');


### PR DESCRIPTION
When we get a `SyntaxError` from `readJson`, the error object itself will be decorated/modified for better printing. (every other case still behaves the same)

In the `duo(1)` CLI, it will treat the decorated `SyntaxError` as a special-case, and print w/o a stack trace. Instead, it includes the error and filename relative to `pwd`. I thought about using root instead, but figured since we were printing on the CLI, it would make more sense to be relative to the `pwd`.

This fixes #408 