### PR TITLE
Updating duo-parse to allow semver deps

### DIFF
--- a/examples/entry/another.js
+++ b/examples/entry/another.js
@@ -2,7 +2,7 @@
  * Module Dependencies
  */
 
-var shortcuts = require('yields/shortcuts/index');
+var shortcuts = require('yields/shortcuts');
 var ware = require('ware');
 
 module.exports = ware;

--- a/lib/duo.js
+++ b/lib/duo.js
@@ -945,7 +945,7 @@ Duo.prototype.findDependency = function(dep, manifest) {
 Duo.prototype.findRoot = function (path) {
   var root = this.root();
 
-  while (path != '.' && path != root && !slug(path)) {
+  while (path != '.' && path != root && !isSlug(basename(path))) {
     path = dirname(path);
   }
 
@@ -954,10 +954,6 @@ Duo.prototype.findRoot = function (path) {
   }
 
   return path;
-
-  function slug(path) {
-    return parse.slug.test(basename(path));
-  }
 };
 
 /**
@@ -1162,4 +1158,21 @@ function includeDeps(src, type) {
     acc[dep] = dep;
     return acc;
   }, {});
+}
+
+/**
+ * Parses a path string to see if it is a dependency slug (where a slug is the
+ * dirname for an installed dependency)
+ *
+ * @param {String} str
+ * @returns {Boolean}
+ */
+
+function isSlug(str) {
+  var repo = /([A-Za-z0-9-_\.]+)/;
+  var user = /([A-Za-z0-9-]{1,39})/;
+  var ref = /([A-Za-z0-9-_\/\.$!#%&\(\)\+=\*]+)/;
+  var regex = new RegExp(user.source + '-' + repo.source + '@' + ref.source, 'i');
+
+  return regex.test(str);
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "duo-main": "^0.0.3",
     "duo-pack": "1.0.10",
     "duo-package": "^0.5.1",
-    "duo-parse": "^0.1.1",
+    "duo-parse": "^0.2.0",
     "duo-string-to-js": "~0.1.0",
     "duo-test": "0.x",
     "duo-watch": "^0.1.1",

--- a/test/api.js
+++ b/test/api.js
@@ -355,6 +355,12 @@ describe('Duo API', function () {
       assert('string' == type(''));
     });
 
+    it('should fetch dependencies via semver ranges', function *() {
+      var js = yield build('deps-semver').run();
+      var ctx = evaluate(js).main;
+      assert.equal(ctx, 'function');
+    });
+
     it('should be idempotent', function *() {
       var a = yield build('idempotent').run();
       var b = yield build('idempotent').run();

--- a/test/fixtures/deps-semver/index.js
+++ b/test/fixtures/deps-semver/index.js
@@ -1,0 +1,3 @@
+var classes = require('component/classes@^1.2.1');
+
+module.exports = typeof classes;


### PR DESCRIPTION
I've updated to `duo-parse@0.2.0` here, which unfortunately broke the tests due to an [undocumented/untested export](https://github.com/duojs/parse/blob/0.1.1/index.js#L16) that wasn't accounted for in the recent refactor. (but that's good, because it was pretty tightly coupled and I don't think belonged there anyways)

Also, one of the examples had a weird slug (`yields/shortcuts/index`) that broke the test, and I don't believe we want to support that syntax, so I've just changed it. (correct me if I'm wrong)

This will fix #385, and I've even added a test to make sure of that. :)
