### PR TITLE
feat(transpilation-plugins): default extension of required files to exte...

### DIFF
--- a/lib/duo.js
+++ b/lib/duo.js
@@ -713,7 +713,7 @@ Duo.prototype.dependency = function *(dep, file, entry) {
 
 Duo.prototype.resolve = function *(dep, file, entry) {
   var isManifest = this.manifest() == basename(dep);
-  var ext = extension(dep) ? '' : '.' + entry.type;
+  var ext = extension(dep) ? '' : '.' + extension(entry.path);
   var path = resolve(dirname(file.path), dep);
   var isRelative = './' == dep.slice(0, 2);
   var isParent = '..' == dep.slice(0, 2);

--- a/test/fixtures/coffee/index.coffee
+++ b/test/fixtures/coffee/index.coffee
@@ -1,4 +1,1 @@
-module.exports =
-  a: 'a'
-  b: 'b'
-  c: 'c'
+ module.exports = require('./one');

--- a/test/fixtures/coffee/one.coffee
+++ b/test/fixtures/coffee/one.coffee
@@ -1,0 +1,4 @@
+module.exports =
+  a: 'a'
+  b: 'b'
+  c: 'c'


### PR DESCRIPTION
...nsion of entry file

I'm working on a typescript compiler for duo but I have run into this problem, currently duo will default the extension of required files to the *type*  of the entry file (entry.type). The problem is that I have transpiled the entry file and changed its type from 'ts' to 'js' as shown in the coffeescript example. This means that the dependent files are not found as duo is looking for dep.js instead of dep.ts

```ts
import dep = require("./dep"); // should go to dep.ts
```

I cannot specify the extension in the require because the typescript compiler does not expect require paths to have extensions. I believe that coffeescript also lets you omit the .coffee extension but I'm not certain about that.

This fix is to use the extension of the entry file as the default instead of entry.type (which can change). A better solution might be to try both extensions.

It will have no impact on existing javascript libraries. (when extension(entry.path) == entry.type).

I welcome your feedback, thanks
