### PR TITLE
Easier example HTML

### DIFF
--- a/bin/_duo
+++ b/bin/_duo
@@ -63,6 +63,7 @@ var program = new Command('duo')
   .option('-v, --verbose', 'show as much logs as possible', false)
   .option('-w, --watch', 'watch for changes and rebuild', false)
   .option('-s, --standalone <standalone>', 'outputs standalone javascript umd <standalone>', '')
+  .option('--with_require <module>', 'define require("<module>") for HTML', '')
   .option('-S, --stdout', 'outputs build to stdout', false)
   .parse(process.argv);
 
@@ -96,6 +97,8 @@ program.on('--help', function () {
   console.log();
   process.exit(0);
 });
+
+
 
 /**
  * Language mapping.
@@ -295,8 +298,12 @@ function create(entry) {
     .cache(program.cache);
 
   // standalone
-  var name = program.standalone;
-  name && duo.standalone(name);
+  var standalone = program.standalone;
+  standalone && duo.standalone(standalone);
+
+  // with_require
+  var with_require = program.with_require;
+  with_require && duo.with_require(with_require);
 
   // global
   program.global && duo.global(program.global);

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -16,10 +16,11 @@
       -q, --quiet                    only print to stderr when there is an error
       -r, --root <dir>               root directory to build from.
       -t, --type <type>              set the entry type
-      -u, --use <plugin>             use transform plugin
+      -u, --use <plugin>             use transform plugin(s)
       -v, --verbose                  show as much logs as possible
       -w, --watch                    watch for changes and rebuild
       -s, --standalone <standalone>  outputs standalone javascript umd <standalone>
+      --with_require <module>        define require("<module>") for HTML
       -S, --stdout                   outputs build to stdout
 
 ## Examples
@@ -43,6 +44,9 @@ $ duo < in.css > out.css
 # build using a plugin
 $ npm install duo-whitespace
 $ duo --use duo-whitespace in.styl > out.css
+
+# build for HTML that uses <script>require('my-module');</script>
+$ duo --with_require my-module index.js
 ```
 
 ## Commands

--- a/lib/duo.js
+++ b/lib/duo.js
@@ -187,6 +187,20 @@ Duo.prototype.standalone = function(name){
 };
 
 /**
+ * Get or set module name to export with require()
+ *
+ * @param {String} module_name
+ * @return {String|Duo}
+ * @api public
+ */
+
+Duo.prototype.with_require = function(module_name){
+  if (!arguments.length) return this.module_name;
+  this.module_name = module_name;
+  return this;
+};
+
+/**
  * Get or set whether to install development dependencies.
  *
  * @param {Boolean} value (optional)
@@ -467,6 +481,9 @@ Duo.prototype.run = unyield(function *() {
     deps[rel].name = this.standalone();
     opts.umd = true;
   }
+
+  // define require()?
+  opts.with_require = this.with_require();
 
   // pack the mapping
   var pack = Pack(deps, opts);


### PR DESCRIPTION
Adds --with_require to make example HTML easier. See https://github.com/duojs/duo/issues/350

For example, you could run:
```
$ duo --with_require cursor-move index.js
```

Then use this in example.html:
```HTML
<script src="build/index.js"></script>
<script>
var Cursor = require('cursor-move');
...
</script>
```