### PR TITLE
switching to ware instead of step.js

### DIFF
--- a/lib/duo.js
+++ b/lib/duo.js
@@ -21,8 +21,8 @@ var thunk = require('thunkify');
 var Pack = require('duo-pack');
 var main = require('duo-main');
 var mkdir = require('mkdirp');
-var Step = require('step.js');
 var File = require('./file');
+var Ware = require('ware');
 var fs = require('co-fs');
 var co = require('co');
 var cp = require('cp');
@@ -75,7 +75,7 @@ function Duo(root) {
   this.json = readJson(this.path('component.json'));
 
   // plugins
-  this.plugins = new Step;
+  this.plugins = new Ware;
   this.plugins.run = thunk(this.plugins.run);
 }
 
@@ -279,17 +279,21 @@ Duo.prototype.buildTo = function (path) {
  */
 
 Duo.prototype.use = function (fn) {
+  this.plugins.use(fn);
+
   if (Array.isArray(fn)) {
-    fn.forEach(this.use, this);
-    return this;
+    fn.forEach(log, this);
   } else {
-    if (~this.plugins.fns.indexOf(fn)) return this;
+    log.call(this, fn);
+  }
+
+  function log(fn) {
     var name = fn.name || '(anonymous)';
     this.emit('plugin', name);
     debug('using plugin: %s', name);
-    this.plugins.use(fn);
-    return this;
   }
+
+  return this;
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -46,10 +46,10 @@
     "max-component": "~1.0.0",
     "mkdirp": "^0.5.0",
     "node-netrc": "0.0.1",
-    "step.js": "~2.0.2",
     "stream-log": "0.1.0",
     "thunkify": "~2.1.1",
     "unyield": "0.0.1",
+    "ware": "^1.2.0",
     "win-fork": "^1.1.1"
   },
   "devDependencies": {

--- a/test/api.js
+++ b/test/api.js
@@ -693,8 +693,8 @@ describe('Duo API', function () {
         a.use(function ap() {});
         b.use(function bp() {});
 
-        assert(1 == a.plugins.length);
-        assert(1 == b.plugins.length);
+        assert(1 == a.plugins.fns.length);
+        assert(1 == b.plugins.fns.length);
       });
     });
 


### PR DESCRIPTION
At first, I upgraded step.js to get better sync error support, but it turns out that @MatthewMueller wanted to switch over to ware for this particular use-case anyways.

/cc @duojs/owners 