### PR TITLE
Adds log for written files

### DIFF
--- a/bin/_duo
+++ b/bin/_duo
@@ -33,7 +33,7 @@ var cwd = process.cwd();
 var logger = new Logger(process.stderr)
   .type('building', '36m')
   .type('built', '36m')
-  .type('written', '36m')
+  .type('wrote', '36m')
   .type('installing', '36m')
   .type('installed', '36m')
   .type('finding', '36m')
@@ -312,7 +312,7 @@ function create(entry) {
     duo.on('install', log('installed'));
     duo.on('running', log('building'));
     duo.on('run', log('built'));
-    duo.on('write', log('written'));
+    duo.on('write', log('wrote'));
   }
 
   // output dir

--- a/bin/_duo
+++ b/bin/_duo
@@ -33,6 +33,7 @@ var cwd = process.cwd();
 var logger = new Logger(process.stderr)
   .type('building', '36m')
   .type('built', '36m')
+  .type('written', '36m')
   .type('installing', '36m')
   .type('installed', '36m')
   .type('finding', '36m')
@@ -311,6 +312,7 @@ function create(entry) {
     duo.on('install', log('installed'));
     duo.on('running', log('building'));
     duo.on('run', log('built'));
+    duo.on('write', log('written'));
   }
 
   // output dir

--- a/lib/duo.js
+++ b/lib/duo.js
@@ -438,8 +438,15 @@ Duo.prototype.write = unyield(function *(path) {
   // write the file
   yield mkdir(dir);
 
-  if (results.code) yield fs.writeFile(path, results.code);
-  if (results.map) yield fs.writeFile(path + '.map', results.map);
+  if (results.code) {
+    yield fs.writeFile(path, results.code);
+    this.emit('write', base);
+  }
+
+  if (results.map) {
+    yield fs.writeFile(path + '.map', results.map);
+    this.emit('write', base + '.map');
+  }
 
   return this;
 });

--- a/test/cli.js
+++ b/test/cli.js
@@ -118,11 +118,11 @@ describe('Duo CLI', function () {
       assert(src.trim() == 'module.exports = \'two\';');
     });
 
-    it('should log that the map was written', function *() {
+    it('should log that the map was wrote', function *() {
       var out = yield exec('--external-source-maps index.js', 'simple');
       if (out.error) throw out.error;
-      assert(contains(out.stderr, 'written : index.js'));
-      assert(contains(out.stderr, 'written : index.js.map'));
+      assert(contains(out.stderr, 'wrote : index.js'));
+      assert(contains(out.stderr, 'wrote : index.js.map'));
     });
   });
 
@@ -136,10 +136,10 @@ describe('Duo CLI', function () {
       assert('index' == index.main);
       assert(contains(out.stderr, 'building : admin.js'));
       assert(contains(out.stderr, 'built : admin.js'));
-      assert(contains(out.stderr, 'written : admin.js'));
+      assert(contains(out.stderr, 'wrote : admin.js'));
       assert(contains(out.stderr, 'building : index.js'));
       assert(contains(out.stderr, 'built : index.js'));
-      assert(contains(out.stderr, 'written : index.js'));
+      assert(contains(out.stderr, 'wrote : index.js'));
       assert(!out.stdout);
     });
 
@@ -166,10 +166,10 @@ describe('Duo CLI', function () {
       assert('index' == index.main);
       assert(contains(out.stderr, 'building : admin.js'));
       assert(contains(out.stderr, 'built : admin.js'));
-      assert(contains(out.stderr, 'written : admin.js'));
+      assert(contains(out.stderr, 'wrote : admin.js'));
       assert(contains(out.stderr, 'building : index.js'));
       assert(contains(out.stderr, 'built : index.js'));
-      assert(contains(out.stderr, 'written : index.js'));
+      assert(contains(out.stderr, 'wrote : index.js'));
       assert(!out.stdout);
     });
 
@@ -182,10 +182,10 @@ describe('Duo CLI', function () {
       assert('index' == index.main);
       assert(contains(out.stderr, 'building : admin.js'));
       assert(contains(out.stderr, 'built : admin.js'));
-      assert(contains(out.stderr, 'written : admin.js'));
+      assert(contains(out.stderr, 'wrote : admin.js'));
       assert(contains(out.stderr, 'building : index.js'));
       assert(contains(out.stderr, 'built : index.js'));
-      assert(contains(out.stderr, 'written : index.js'));
+      assert(contains(out.stderr, 'wrote : index.js'));
       assert(!exists('entries/out/*.css'));
       assert(!out.stdout);
     });

--- a/test/cli.js
+++ b/test/cli.js
@@ -118,7 +118,7 @@ describe('Duo CLI', function () {
       assert(src.trim() == 'module.exports = \'two\';');
     });
 
-    it('should log that the map was wrote', function *() {
+    it('should log that the map was written', function *() {
       var out = yield exec('--external-source-maps index.js', 'simple');
       if (out.error) throw out.error;
       assert(contains(out.stderr, 'wrote : index.js'));

--- a/test/cli.js
+++ b/test/cli.js
@@ -117,6 +117,13 @@ describe('Duo CLI', function () {
       var src = map.sourcesContent[map.sources.indexOf('two.js')];
       assert(src.trim() == 'module.exports = \'two\';');
     });
+
+    it('should log that the map was written', function *() {
+      var out = yield exec('--external-source-maps index.js', 'simple');
+      if (out.error) throw out.error;
+      assert(contains(out.stderr, 'written : index.js'));
+      assert(contains(out.stderr, 'written : index.js.map'));
+    });
   });
 
   describe('duo [file, ...]', function () {
@@ -129,8 +136,10 @@ describe('Duo CLI', function () {
       assert('index' == index.main);
       assert(contains(out.stderr, 'building : admin.js'));
       assert(contains(out.stderr, 'built : admin.js'));
+      assert(contains(out.stderr, 'written : admin.js'));
       assert(contains(out.stderr, 'building : index.js'));
       assert(contains(out.stderr, 'built : index.js'));
+      assert(contains(out.stderr, 'written : index.js'));
       assert(!out.stdout);
     });
 
@@ -157,8 +166,10 @@ describe('Duo CLI', function () {
       assert('index' == index.main);
       assert(contains(out.stderr, 'building : admin.js'));
       assert(contains(out.stderr, 'built : admin.js'));
+      assert(contains(out.stderr, 'written : admin.js'));
       assert(contains(out.stderr, 'building : index.js'));
       assert(contains(out.stderr, 'built : index.js'));
+      assert(contains(out.stderr, 'written : index.js'));
       assert(!out.stdout);
     });
 
@@ -171,8 +182,10 @@ describe('Duo CLI', function () {
       assert('index' == index.main);
       assert(contains(out.stderr, 'building : admin.js'));
       assert(contains(out.stderr, 'built : admin.js'));
+      assert(contains(out.stderr, 'written : admin.js'));
       assert(contains(out.stderr, 'building : index.js'));
       assert(contains(out.stderr, 'built : index.js'));
+      assert(contains(out.stderr, 'written : index.js'));
       assert(!exists('entries/out/*.css'));
       assert(!out.stdout);
     });


### PR DESCRIPTION
This adds a "write" event internally that is trigged after writing a file. The first use-case is obvious, it shows when the entry file was successfully written. Now that external source-maps are a thing, this will now show when _that_ write is successful too.

## Current

```sh
$ duo index.js

     building : index.js
        using : compatibility
        using : stoj
        built : index.js

```

## Now

```sh
$ duo index.js

       building : index.js
          using : compatibility
          using : stoj
          built : index.js
        written : index.js

```

## Now (with external source-map)

```sh
$ duo --external-source-maps index.js

     building : index.js
        using : compatibility
        using : stoj
        built : index.js
      written : index.js
      written : index.js.map

```