### PR TITLE
Adding duo-install

### DIFF
--- a/bin/_duo
+++ b/bin/_duo
@@ -4,24 +4,20 @@
  * Module dependencies.
  */
 
-var detect = require('language-classifier');
 var convert = require('convert-source-map');
 var Command = require('commander').Command;
 var relative = require('path').relative;
-var exists = require('fs').existsSync;
 var resolve = require('path').resolve;
 var dirname = require('path').dirname;
 var extname = require('path').extname;
 var mkdirp = require('mkdirp').sync;
 var Logger = require('stream-log');
-var stat = require('fs').statSync;
-var netrc = require('node-netrc');
+var util = require('../lib/util');
 var stdin = require('get-stdin');
 var Watch = require('duo-watch');
 var join = require('path').join;
 var spawn = require('win-fork');
 var pkg = require('../package');
-var glob = require('glob').sync;
 var Batch = require('batch');
 var stdout = process.stdout;
 var cwd = process.cwd();
@@ -52,14 +48,6 @@ logger.type('error', '31m', function () {
 });
 
 /**
- * GitHub credentials.
- */
-
-var auth = netrc('api.github.com') || {
-  password: process.env.GH_TOKEN
-};
-
-/**
  * Program.
  */
 
@@ -75,7 +63,7 @@ var program = new Command('duo')
   .option('-q, --quiet', 'only print to stderr when there is an error', false)
   .option('-r, --root <dir>', 'root directory to build from.', null)
   .option('-t, --type <type>', 'set the entry type', null)
-  .option('-u, --use <plugin>', 'use transform plugin(s)', collect, [])
+  .option('-u, --use <plugin>', 'use transform plugin(s)', util.collect, [])
   .option('-v, --verbose', 'show as much logs as possible', false)
   .option('-w, --watch', 'watch for changes and rebuild', false)
   .option('-s, --standalone <standalone>', 'outputs standalone javascript umd <standalone>', '')
@@ -107,20 +95,12 @@ program.on('--help', function () {
   console.log();
   console.log('  Commands:');
   console.log();
+  console.log('    install      install dependencies for a file.');
   console.log('    ls           list all dependencies.');
   console.log('    duplicates   show all duplicates.');
   console.log();
   process.exit(0);
 });
-
-/**
- * Language mapping.
- */
-
-var langmap = {
-  javascript: 'js',
-  css: 'css'
-};
 
 /**
  * Quiet flag.
@@ -147,7 +127,7 @@ if (quiet && verbose) {
  * Root.
  */
 
-var root = findroot(program.root);
+var root = util.findroot(program.root);
 
 /**
  * Asset path.
@@ -165,13 +145,24 @@ var watching = false;
  * Plugins.
  */
 
-var plugins = use(program.use);
+try {
+  var plugins = util.plugins(root, program.use);
+} catch (err) {
+  error(err);
+}
 
 /**
  * Source maps.
  */
 
 var sourceMap = sourcemap(program.development, program.externalSourceMaps);
+
+/**
+ * GitHub Authentication.
+ */
+
+var auth = util.auth();
+
 /**
  * Stdout.
  */
@@ -186,7 +177,7 @@ if (program.stdout && program.args.length > 1) {
  */
 
 if (program.stdout && program.args.length) print(program.args[0]);
-else if (program.args.length) write(entries(program.args));
+else if (program.args.length) write(util.entries(root, program.args));
 else if (!process.stdin.isTTY) input();
 else program.help();
 
@@ -196,7 +187,7 @@ else program.help();
 
 function input() {
   stdin(function (src) {
-    var type = program.type || langmap[detect(src)];
+    var type = program.type || util.type(src);
     if (!type) logger.error('could not detect the file type');
     var duo = create(root).entry(src, type);
 
@@ -340,21 +331,6 @@ function watch(action) {
 }
 
 /**
- * Log an event.
- *
- * @param {String} event
- * @return {Function}
- */
-
-function log(event) {
-  return function (pkg) {
-    pkg = pkg.slug ? pkg.slug() : pkg;
-    pkg = 'source.' + (program.type || 'js') == pkg ? 'from stdin' : pkg;
-    logger[event](pkg);
-  };
-}
-
-/**
  * Error.
  */
 
@@ -370,123 +346,18 @@ function error(err) {
 }
 
 /**
- * Find the root.
+ * Log an event.
  *
- * @param {String} root
- * @param {String}
+ * @param {String} event
+ * @return {Function}
  */
 
-function findroot(root) {
-  if (root) return resolve(cwd, root);
-  var sep = require('path').sep;
-  var parts = cwd.split(sep);
-  var path = cwd;
-
-  while (!exists(join(path, 'component.json')) && parts.length > 1) {
-    parts.pop();
-    path = parts.join(sep);
-  }
-
-  return parts.length <= 1
-    ? cwd
-    : path;
-}
-
-/**
- * Filter out unexpanded globs.
- *
- * @param {String} entry
- * @return {Boolean}
- */
-
-function globs(path) {
-  return !/\*/.test(path);
-}
-
-/**
- * Simple hueristic to check if `path` is a directory.
- *
- * @param {String} path
- * @return {Boolean}
- */
-
-function isDir(path) {
-  try {
-    return stat(path).isDirectory();
-  } catch (e) {
-    return false;
-  }
-}
-
-/**
- * Gets a list of all files within a directory recursively (and synchronously)
- *
- * @param {String} path
- * @return {Array:String}
- */
-
-function listFiles(path, pattern) {
-  var opts = { cwd: root, nodir: true };
-  return glob(join(path, pattern || '**/*'), opts);
-}
-
-/**
- * Retrieve an array of plugins from `--use`.
- *
- * @param {Array:String} plugins
- * @return {Array:Function}
- */
-
-function use(plugins) {
-  return plugins.map(function (plugin) {
-    try {
-      var local = resolve(root, plugin);
-      var npm = resolve(root, "node_modules", plugin);
-      var cwd = resolve(process.cwd(), "node_modules", plugin);
-      var mod;
-
-      if (exists(local)) mod = require(local);
-      else if (exists(local + '.js')) mod = require(local);
-      else if (exists(npm)) mod = require(npm);
-      else mod = require(cwd);
-
-      return Array.isArray(mod) ? mod : mod();
-    } catch (e) {
-      error(e);
-    }
-  }, []);
-}
-
-/**
- * Helper to capture list of plugins from CLI
- */
-
-function collect(val, memo) {
-  val.split(',').forEach(function (val) {
-    memo.push(val);
-  });
-
-  return memo;
-}
-
-/**
- * Normalize entries list.
- *
- *  - expand globs
- *  - expand directories into list of all nested files
- *
- * @param {Array:String}
- * @return {Array:String}
- */
-
-function entries(list) {
-  return list.filter(globs).reduce(function (memo, entry) {
-    if (isDir(join(root, entry))) {
-      return memo.concat(listFiles(entry));
-    } else {
-      return memo.concat(entry);
-    }
-  }, []);
+function log(event) {
+  return function (pkg) {
+    pkg = pkg.slug ? pkg.slug() : pkg;
+    pkg = 'source.' + (program.type || 'js') == pkg ? 'from stdin' : pkg;
+    logger[event](pkg);
+  };
 }
 
 /**

--- a/bin/duo-install
+++ b/bin/duo-install
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+
+/**
+ * Module dependencies.
+ */
+
+var relative = require('path').relative;
+var resolve = require('path').resolve;
+var program = require('commander');
+var Logger = require('stream-log');
+var util = require('../lib/util');
+var stdin = require('get-stdin');
+var join = require('path').join;
+var pkg = require('../package');
+var Batch = require('batch');
+var cwd = process.cwd();
+
+/**
+ * Logger.
+ */
+
+var logger = new Logger(process.stderr)
+  .type('building', '36m')
+  .type('built', '36m')
+  .type('installing', '36m')
+  .type('installed', '36m')
+  .type('finding', '36m')
+  .type('found', '36m')
+  .type('using', '36m');
+
+/**
+ * Error.
+ */
+
+logger.type('error', '31m', function () {
+  if (!quiet) logger.end();
+  process.exit(1);
+});
+
+/**
+ * Program.
+ */
+
+program
+  .usage('duo install file...')
+  .option('-c, --copy', 'opt to copy files instead of symlink', false)
+  .option('-C, --no-cache', 'enable or disable the cache during build', true)
+  .option('-d, --development', 'include development dependencies and include an inline source-map', false)
+  .option('-q, --quiet', 'only print to stderr when there is an error', false)
+  .option('-r, --root <dir>', 'root directory to build from.', null)
+  .option('-t, --type <type>', 'set the entry type', null)
+  .option('-u, --use <plugin>', 'use transform plugin(s)', util.collect, [])
+  .option('-v, --verbose', 'show as much logs as possible', false)
+  .parse(process.argv);
+
+/**
+ * Examples.
+ */
+
+program.on('--help', function () {
+  console.log('  Examples:');
+  console.log();
+  console.log('    # install dependencies for index.js and index.css');
+  console.log('    $ duo install index.{js,css}');
+  console.log();
+  console.log('    # include transform plugins');
+  console.log('    $ duo install --use duo-babel index.{js,css}');
+  console.log();
+  process.exit(0);
+});
+
+/**
+ * Quiet flag.
+ */
+
+var quiet = program.quiet;
+
+/**
+ * Verbose flag.
+ */
+
+var verbose = program.verbose;
+
+/**
+ * Only quite *or* verbose should be enabled, never both.
+ */
+
+if (quiet && verbose) {
+  logger.error('cannot use both quiet and verbose mode simultaneously');
+  return;
+}
+
+/**
+ * GitHub credentials.
+ */
+
+var auth = util.auth();
+
+/**
+ * Root.
+ */
+
+var root = util.findroot(program.root);
+
+/**
+ * Plugins.
+ */
+
+try {
+  var plugins = util.plugins(root, program.use);
+} catch (err) {
+  error(err);
+}
+
+/**
+ * Actions.
+ */
+
+if (program.args.length) write(util.entries(root, program.args));
+else if (!process.stdin.isTTY) input();
+else program.help();
+
+/**
+ * Accept standard input.
+ */
+
+function input() {
+  stdin(function (src) {
+    var type = program.type || util.type(src);
+    if (!type) logger.error('could not detect the file type');
+    var duo = create(root).entry(src, type);
+
+    duo.install(function (err, mapping) {
+      if (err) throw error(err);
+      logger.end();
+      process.exit(0);
+    });
+  });
+}
+
+/**
+ * Write the entries.
+ *
+ * @param {Array} entries
+ */
+
+function write(entries) {
+  if ('string' == typeof entries) entries = [entries];
+
+  var batch = new Batch;
+  var push = batch.push.bind(batch);
+
+  var duos = entries
+    .map(multiple)
+    .map(push);
+
+  batch.end(function (err) {
+    if (err) return error(err);
+    if (!quiet) logger.end();
+    process.exit(0);
+  });
+
+  // write multiple entries to
+  // the directory `out`
+  function multiple(entry) {
+    return function (done) {
+      create(entry).install(done);
+    };
+  }
+}
+
+/**
+ * Create a duo instance.
+ *
+ * @param {entry} entry
+ * @return {Duo}
+ */
+
+function create(entry) {
+  var duo = Duo(root)
+    .entry(resolve(program.root || cwd, entry))
+    .copy(program.copy)
+    .token(auth.password)
+    .cache(program.cache);
+
+  // events
+  if (!quiet) {
+    if (verbose) {
+      duo.on('resolving', log('finding'));
+      duo.on('resolve', log('found'));
+      duo.on('installing', log('installing'));
+    }
+
+    duo.on('plugin', log('using'));
+    duo.on('install', log('installed'));
+    duo.on('running', log('building'));
+    duo.on('run', log('built'));
+  }
+
+  // use plugins
+  plugins.forEach(duo.use, duo);
+
+  return duo;
+}
+
+/**
+ * Error.
+ */
+
+function error(err) {
+  err = 'string' == typeof err ? new Error(err) : err;
+  if (err instanceof SyntaxError && err.fileName) {
+    var msg = err.message;
+    var file = relative(process.cwd(), err.fileName);
+    logger.error('Syntax error:', msg, 'in:', file);
+  } else {
+    logger.error(err.stack);
+  }
+}
+
+/**
+ * Log an event.
+ *
+ * @param {String} event
+ * @return {Function}
+ */
+
+function log(event) {
+  return function (pkg) {
+    pkg = pkg.slug ? pkg.slug() : pkg;
+    pkg = 'source.' + (program.type || 'js') == pkg ? 'from stdin' : pkg;
+    logger[event](pkg);
+  };
+}
+
+/**
+ * Lazy-load Duo
+ */
+
+function Duo() {
+  var duo = require('..');
+  return duo.apply(duo, arguments);
+}

--- a/lib/duo.js
+++ b/lib/duo.js
@@ -452,29 +452,22 @@ Duo.prototype.write = unyield(function *(path) {
 });
 
 /**
- * Run duo on the entry file and return the built source.
+ * Processes the entry file and generates it's mapping,
+ * by separating out this step, we can effectively implement
+ * a `duo install` that will fetch dependencies.
  *
- * - Loads core duo plugins.
- * - Map out the dependency grpah.
- * - Add in the manually included files.
- * - Write the assets to the `buildTo()` path.
- * - Write out the map of the dependency graph to `components/duo.json`.
- * - Build the source by passing the `mapping` into duo-pack.
- *
- * @param {Function} fn (optional)
- * @return {String}
+ * @returns {Object} deps mapping
  * @api public
  */
 
-Duo.prototype.run = unyield(function *() {
-  if (!this.entry()) return '';
+Duo.prototype.install = unyield(function *() {
+  var entry = this.entry();
+  if (!entry) return {};
 
+  var rel = entry.id;
   var path = this.installPath('duo.json');
   var mapping = Mapping(path);
   var global = this.global();
-  var file = this.entry();
-  var rel = file.id;
-  var opts = {};
 
   // logging
   this.emit('running', rel);
@@ -492,12 +485,12 @@ Duo.prototype.run = unyield(function *() {
   if (this.cache()) this.mapping = yield mapping.read();
 
   // ensure that the entry exists
-  if (!(yield file.exists())) {
+  if (!(yield entry.exists())) {
     throw error('cannot find entry: %s', rel);
   }
 
   // fetch the map of the dependency graph
-  var deps = yield this.dependencies(file);
+  var deps = yield this.dependencies(entry);
 
   // add "includes" to dependency mapping
   deps = extend(deps, this.includes);
@@ -515,11 +508,35 @@ Duo.prototype.run = unyield(function *() {
   // standalone?
   if (this.standalone()) {
     deps[rel].name = this.standalone();
-    opts.umd = true;
   }
 
+  return deps;
+});
+
+/**
+ * Run duo on the entry file and return the built source.
+ *
+ * - Loads core duo plugins.
+ * - Map out the dependency grpah.
+ * - Add in the manually included files.
+ * - Write the assets to the `buildTo()` path.
+ * - Write out the map of the dependency graph to `components/duo.json`.
+ * - Build the source by passing the `mapping` into duo-pack.
+ *
+ * @param {Function} fn (optional)
+ * @return {String}
+ * @api public
+ */
+
+Duo.prototype.run = unyield(function *() {
+  var entry = this.entry();
+  if (!entry) return { code: '' }; // TODO: throw error instead?
+
+  var rel = entry.id;
+  var deps = yield this.install();
+
   // pack the mapping
-  var pack = Pack(deps, opts);
+  var pack = Pack(deps, { umd: this.standalone() });
   var map = this.sourceMap();
   if (map) pack.sourceMap(map);
   var results = pack.pack(rel);

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,164 @@
+
+/**
+ * Module dependencies.
+ */
+
+var detect = require('language-classifier');
+var resolve = require('path').resolve;
+var exists = require('fs').existsSync;
+var stat = require('fs').statSync;
+var netrc = require('node-netrc');
+var glob = require('glob').sync;
+var path = require('path');
+
+/**
+ * Language mapping.
+ */
+
+var langmap = {
+  javascript: 'js',
+  css: 'css'
+};
+
+/**
+ * Pull GH auth from ~/.netrc or $GH_TOKEN.
+ */
+
+exports.auth = function () {
+  return netrc('api.github.com') || {
+    password: process.env.GH_TOKEN
+  };
+};
+
+/**
+ * Normalize entries list.
+ *
+ *  - expand globs
+ *  - expand directories into list of all nested files
+ *
+ * @param {Array:String}
+ * @return {Array:String}
+ */
+
+exports.entries = function (root, list) {
+  return list.filter(globs).reduce(function (memo, entry) {
+    if (isDir(path.join(root, entry))) {
+      return memo.concat(listFiles(root, entry));
+    } else {
+      return memo.concat(entry);
+    }
+  }, []);
+};
+
+/**
+ * Helper for collecting CLI params into a single array.
+ *
+ * @param {String} val
+ * @param {Array:String} memo
+ * @returns {Array:String}
+ */
+
+exports.collect = function (val, memo) {
+  val.split(',').forEach(function (val) {
+    memo.push(val);
+  });
+
+  return memo;
+};
+
+/**
+ * Find the root.
+ *
+ * @param {String} root
+ * @param {String}
+ */
+
+exports.findroot = function (root) {
+  var cwd = process.cwd();
+  if (root) return resolve(cwd, root);
+  var sep = path.sep;
+  var parts = cwd.split(sep);
+  var dir = cwd;
+
+  while (!exists(path.join(dir, 'component.json')) && parts.length > 1) {
+    parts.pop();
+    dir = parts.join(sep);
+  }
+
+  return parts.length <= 1
+    ? cwd
+    : dir;
+};
+
+/**
+ * Detect the type of a source-file.
+ *
+ * @param {String} src
+ * @returns {String}
+ */
+
+exports.type = function (src) {
+  return langmap[detect(src)];
+};
+
+/**
+ * Retrieve an array of plugins from `--use`.
+ *
+ * @param {Array:String} plugins
+ * @return {Array:Function}
+ */
+
+exports.plugins = function (root, plugins) {
+  return plugins.map(function (plugin) {
+    var local = resolve(root, plugin);
+    var npm = resolve(root, "node_modules", plugin);
+    var cwd = resolve(process.cwd(), "node_modules", plugin);
+    var mod;
+
+    if (exists(local)) mod = require(local);
+    else if (exists(local + '.js')) mod = require(local);
+    else if (exists(npm)) mod = require(npm);
+    else mod = require(cwd);
+
+    return Array.isArray(mod) ? mod : mod();
+  }, []);
+};
+
+
+/**
+ * Filter out unexpanded globs.
+ *
+ * @param {String} entry
+ * @return {Boolean}
+ */
+
+function globs(path) {
+  return !/\*/.test(path);
+}
+
+/**
+ * Gets a list of all files within a directory recursively (and synchronously)
+ *
+ * @param {String} path
+ * @return {Array:String}
+ */
+
+function listFiles(root, dir, pattern) {
+  var opts = { cwd: root, nodir: true };
+  return glob(path.join(dir, pattern || '**/*'), opts);
+}
+
+/**
+ * Simple hueristic to check if `path` is a directory.
+ *
+ * @param {String} path
+ * @return {Boolean}
+ */
+
+function isDir(path) {
+  try {
+    return stat(path).isDirectory();
+  } catch (e) {
+    return false;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
   "bin": {
     "duo": "bin/duo",
     "_duo": "bin/_duo",
+    "duo-clean-cache": "bin/duo-clean-cache",
     "duo-duplicates": "bin/duo-duplicates",
-    "duo-ls": "bin/duo-ls",
-    "duo-clean-cache": "bin/duo-clean-cache"
+    "duo-install": "bin/duo-install",
+    "duo-ls": "bin/duo-ls"
   },
   "dependencies": {
     "archy": "0.0.2",

--- a/test/api.js
+++ b/test/api.js
@@ -317,7 +317,7 @@ describe('Duo API', function () {
   describe('.run([fn])', function () {
     it('should ignore runs without an entry or source', function *() {
       var js = yield Duo(__dirname).run();
-      assert.equal('', js);
+      assert.deepEqual(js, { code: '' });
     });
 
     it('should build simple modules', function *() {

--- a/test/cli.js
+++ b/test/cli.js
@@ -480,6 +480,31 @@ describe('Duo CLI', function () {
     });
   });
 
+  describe('duo install file...', function () {
+    it('should download the remote dependencies', function *() {
+      var out = yield exec('install index.js', 'install-deps');
+      if (out.error) throw out.error;
+      assert(exists('install-deps/components/duo.json'));
+      assert(exists('install-deps/components/component-type@1.1.0'));
+      assert(!exists('install-deps/components/suitcss-base@0.8.0'));
+    });
+
+    it('should not output built files', function *() {
+      var out = yield exec('install index.js', 'install-deps');
+      if (out.error) throw out.error;
+      assert(!exists('install-deps/build'));
+    });
+
+    it('should accept multiple entry files', function *() {
+      var out = yield exec('install index.js index.css', 'install-deps');
+      if (out.error) throw out.error;
+      assert(exists('install-deps/components/duo.json'));
+      assert(exists('install-deps/components/component-type@1.1.0'));
+      assert(exists('install-deps/components/suitcss-base@0.8.0'));
+      assert(!exists('install-deps/build'));
+    });
+  });
+
   describe('duo <unsupported command>', function () {
     var res = {};
     beforeEach(function (done) {

--- a/test/fixtures/install-deps/index.css
+++ b/test/fixtures/install-deps/index.css
@@ -1,0 +1,1 @@
+@import "suitcss/base@0.8.0";

--- a/test/fixtures/install-deps/index.js
+++ b/test/fixtures/install-deps/index.js
@@ -1,0 +1,1 @@
+var type = require('component/type@1.1.0');


### PR DESCRIPTION
This adds a `duo-install` command, with semantics _almost_ identical to the normal `duo` command. It's purpose is to take entry files and install all their dependencies. This is useful in cases where you are building a project for the first time and want to have all the deps available w/o necessarilly wanting to build right away.

For instance we're using a middleware to auto-compile each request, but downloading deps on that first request is painfully slow. It feels worse since you're waiting in your browser, so by offloading that work to before you start the server, a lot of that perception of slowness can be addressed.

It's really important to note that this does *not* behave like `component install`, `npm install` or anything else like that. You can't pass arbitrary packages and have it install them. As such, maybe this will remain an under-documented/advanced feature. (since it's not required to use duo normally)

```sh
# install dependencies for index.js/css
duo install index.{js,css}

# include plugins if needed
duo install --use duo-babel --use duo-myth index.{js,css}
```