### PR TITLE
Stops forcefully exiting the process on error

### DIFF
--- a/bin/_duo
+++ b/bin/_duo
@@ -21,6 +21,7 @@ var pkg = require('../package');
 var Batch = require('batch');
 var stdout = process.stdout;
 var cwd = process.cwd();
+var hasError = false;
 
 /**
  * Logger.
@@ -43,7 +44,7 @@ var logger = new Logger(process.stderr)
  */
 
 logger.type('error', '31m', function () {
-  process.exitCode = 1;
+  hasError = true;
 });
 
 /**
@@ -52,6 +53,7 @@ logger.type('error', '31m', function () {
 
 process.on('exit', function () {
   if (!quiet) logger.end();
+  if (hasError) process.exit(1);
 });
 
 /**

--- a/bin/_duo
+++ b/bin/_duo
@@ -43,8 +43,15 @@ var logger = new Logger(process.stderr)
  */
 
 logger.type('error', '31m', function () {
+  process.exitCode = 1;
+});
+
+/**
+ * End logger output.
+ */
+
+process.on('exit', function () {
   if (!quiet) logger.end();
-  process.exit(1);
 });
 
 /**
@@ -149,6 +156,7 @@ try {
   var plugins = util.plugins(root, program.use);
 } catch (err) {
   error(err);
+  return;
 }
 
 /**
@@ -188,15 +196,14 @@ else program.help();
 function input() {
   stdin(function (src) {
     var type = program.type || util.type(src);
-    if (!type) logger.error('could not detect the file type');
+    if (!type) return logger.error('could not detect the file type');
     var duo = create(root).entry(src, type);
 
     // only inline source-maps supported for stdout (if enabled at all)
     if (sourceMap) duo.sourceMap('inline');
 
     duo.run(function (err, results) {
-      if (err) throw error(err);
-      logger.end();
+      if (err) return error(err);
       stdout.write(results.code);
       if (results.map) {
         stdout.write('\n\n');
@@ -221,7 +228,6 @@ function print(entry) {
 
   duo.run(function (err, results) {
     if (err) return error(err);
-    if (!quiet) logger.end();
     if (results.code) stdout.write(results.code);
     if (results.map) {
       stdout.write('\n\n');
@@ -253,7 +259,6 @@ function write(entries) {
 
   batch.end(function (err) {
     if (err) return error(err);
-    if (!quiet) logger.end();
 
     // watch or exit
     program.watch

--- a/bin/duo-clean-cache
+++ b/bin/duo-clean-cache
@@ -8,6 +8,7 @@ var Package = require('duo-package');
 var program = require('commander');
 var Duo = require('..');
 var co = require('co');
+var hasError = false;
 
 /**
  * Logger.
@@ -16,9 +17,17 @@ var co = require('co');
 var logger = require('stream-log')(process.stderr)
   .type('cleaned', '36m')
   .type('error', '31m', function () {
-    logger.end();
-    process.exit(1);
+    hasError = true;
   });
+
+/**
+ * End logger output on finished.
+ */
+
+process.on('exit', function () {
+  if (!quiet) logger.end();
+  if (hasError) process.exit(1);
+});
 
 /**
  * Program.

--- a/bin/duo-install
+++ b/bin/duo-install
@@ -33,8 +33,15 @@ var logger = new Logger(process.stderr)
  */
 
 logger.type('error', '31m', function () {
+  process.exitCode = 1;
+});
+
+/**
+ * End logger output after process exit.
+ */
+
+process.on('exit', function () {
   if (!quiet) logger.end();
-  process.exit(1);
 });
 
 /**
@@ -110,6 +117,7 @@ try {
   var plugins = util.plugins(root, program.use);
 } catch (err) {
   error(err);
+  return;
 }
 
 /**
@@ -127,12 +135,11 @@ else program.help();
 function input() {
   stdin(function (src) {
     var type = program.type || util.type(src);
-    if (!type) logger.error('could not detect the file type');
+    if (!type) return logger.error('could not detect the file type');
     var duo = create(root).entry(src, type);
 
     duo.install(function (err, mapping) {
-      if (err) throw error(err);
-      logger.end();
+      if (err) return error(err);
       process.exit(0);
     });
   });
@@ -156,7 +163,6 @@ function write(entries) {
 
   batch.end(function (err) {
     if (err) return error(err);
-    if (!quiet) logger.end();
     process.exit(0);
   });
 

--- a/bin/duo-install
+++ b/bin/duo-install
@@ -14,6 +14,7 @@ var join = require('path').join;
 var pkg = require('../package');
 var Batch = require('batch');
 var cwd = process.cwd();
+var hasError = false;
 
 /**
  * Logger.
@@ -33,7 +34,7 @@ var logger = new Logger(process.stderr)
  */
 
 logger.type('error', '31m', function () {
-  process.exitCode = 1;
+  hasError = true;
 });
 
 /**
@@ -42,6 +43,7 @@ logger.type('error', '31m', function () {
 
 process.on('exit', function () {
   if (!quiet) logger.end();
+  if (hasError) process.exit(1);
 });
 
 /**

--- a/bin/duo-ls
+++ b/bin/duo-ls
@@ -10,6 +10,7 @@ var join = require('path').join;
 var archy = require('archy');
 var cwd = process.cwd();
 var fs = require('fs');
+var hasError = false;
 
 /**
  * Paths.
@@ -22,8 +23,16 @@ var mapping = join(process.cwd());
  */
 
 logger.type('error', '31m', function () {
+  hasError = true;
+});
+
+/**
+ * End logger output after finished.
+ */
+
+process.on('exit', function () {
   logger.end();
-  process.exit(1);
+  if (hasError) process.exit(1);
 });
 
 /**
@@ -59,6 +68,7 @@ try {
   var map = JSON.parse(read(join(cwd, 'components', 'duo.json')));
 } catch (e) {
   logger.error(e.stack || e);
+  return;
 }
 
 /**
@@ -69,6 +79,7 @@ try {
   var component = JSON.parse(read(join(cwd, 'component.json')));
 } catch (e) {
   logger.error(e.stack || e);
+  return;
 }
 
 /**


### PR DESCRIPTION
I'm starting to parallelize more duo builds in order to be faster and more efficient. I also happen to be in a place with less than perfect internet. When an error is encountered (like a transient timeout) it abruptly stops the entire process, which creates broken state (namely incomplete directories and such) for the next run. The only solution from there is to destroy `components/`. (or manually search for things that look corrupted)

This changes the behavior of the CLI to not exit abruptly on errors, instead in sets `process.exitCode = 1;` and allows the code to continue running. (any errors need to be short-circuited with a `return` to account for the process remaining alive.