### PR TITLE
Adding ESLint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+examples
+components
+test/fixtures

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,17 @@
+{
+  "env": {
+    "node": true
+  },
+  "ecmaFeatures": {
+    "generators": true
+  },
+  "rules": {
+    "consistent-return": 0,
+    "curly": [ 2, "multi-line" ],
+    "no-shadow": 0,
+    "no-underscore-dangle": 0,
+    "no-use-before-define": [ 2, "nofunc" ],
+    "strict": 0,
+    "quotes": [ 2, "single" ]
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,9 @@ NODE ?= node
 NODE_FLAGS ?= $(shell $(NODE) --v8-options | grep generators | cut -d ' ' -f 3)
 
 BIN := ./node_modules/.bin
-MOCHA ?= $(BIN)/_mocha
+ESLINT ?= $(BIN)/eslint
 ISTANBUL ?= $(BIN)/istanbul
+MOCHA ?= $(BIN)/_mocha
 
 SRC = $(wildcard index.js lib/*.js)
 TESTS = $(wildcard test/*.js)
@@ -22,6 +23,9 @@ coverage: $(SRC) $(TESTS)
 clean:
 	@rm -rf coverage test/fixtures/*/{components,deps,out,build.js}
 	@rm -rf examples/*/{components,build*}
+
+lint:
+	@$(ESLINT) .
 
 
 .PHONY: test coverage clean

--- a/lib/duo.js
+++ b/lib/duo.js
@@ -4,7 +4,6 @@
  */
 
 var Emitter = require('events').EventEmitter;
-var convert = require('convert-source-map');
 var clone = require('component-clone');
 var stoj = require('duo-string-to-js');
 var compat = require('duo-css-compat');
@@ -25,10 +24,11 @@ var main = require('duo-main');
 var mkdir = require('mkdirp');
 var File = require('./file');
 var Ware = require('ware');
-var fs = require('co-fs');
-var co = require('co');
-var cp = require('cp');
 var path = require('path');
+var util = require('util');
+var fs = require('co-fs');
+var cp = require('cp');
+
 var basename = path.basename;
 var relative = path.relative;
 var extname = path.extname;
@@ -78,11 +78,11 @@ function Duo(root) {
   this.json = readJson(this.path('component.json'));
 
   // plugins
-  this.plugins = new Ware;
+  this.plugins = new Ware();
   this.plugins.run = thunk(this.plugins.run);
 
   // alternate plugins (used for the full build, not individual files)
-  this.altPlugins = new Ware;
+  this.altPlugins = new Ware();
   this.altPlugins.run = thunk(this.altPlugins.run);
 }
 
@@ -90,7 +90,7 @@ function Duo(root) {
  * Inherit from `Emitter`.
  */
 
-Duo.prototype.__proto__ = Emitter.prototype;
+util.inherits(Duo, Emitter);
 
 /**
  * Get or set the entry file for the package.
@@ -417,7 +417,6 @@ Duo.prototype.included = function (name) {
 
 Duo.prototype.write = unyield(function *(path) {
   var results = yield this.run();
-  var sourceMap = this.sourceMap();
   var entry = this.entry();
   var dir = this.buildPath();
   var type = entry.type;
@@ -430,7 +429,7 @@ Duo.prototype.write = unyield(function *(path) {
 
   // change the extension if the type has changed
   var base = basename(path, extname(path)) + '.' + type;
-  var dir = dirname(path);
+  dir = dirname(path);
 
   // update the path
   path = join(dir, base);
@@ -466,7 +465,7 @@ Duo.prototype.install = unyield(function *() {
 
   var rel = entry.id;
   var path = this.installPath('duo.json');
-  var mapping = Mapping(path);
+  var mapping = new Mapping(path);
   var global = this.global();
 
   // logging
@@ -536,7 +535,7 @@ Duo.prototype.run = unyield(function *() {
   var deps = yield this.install();
 
   // pack the mapping
-  var pack = Pack(deps, { umd: this.standalone() });
+  var pack = new Pack(deps, { umd: this.standalone() });
   var map = this.sourceMap();
   if (map) pack.sourceMap(map);
   var results = pack.pack(rel);
@@ -576,7 +575,7 @@ Duo.prototype.dependencies = function *(file, map) {
   // logging
   debug('parsing: %s', file.id);
 
-  var isCached = file.mtime == json.mtime;
+  var isCached = file.mtime === json.mtime;
   var isIncluded = json.include;
   var isParsed = map[file.id];
 
@@ -610,7 +609,7 @@ Duo.prototype.dependencies = function *(file, map) {
     if (!supported(file.type)) this.assets.push(this.bundle(file.id));
 
     // recurse the dependency's dependencies
-    var gens = this.recurse(paths, map);
+    gens = this.recurse(paths, map);
     yield this.parallel(gens);
     return map;
   }
@@ -635,9 +634,9 @@ Duo.prototype.dependencies = function *(file, map) {
   debug('%s deps: %j', file.id, deps);
 
   // download and resolve the dependencies
-  for (var i = 0, dep; dep = deps[i++];) {
+  deps.forEach(function (dep) {
     depmap[dep] = includes[dep] ? dep : this.dependency(dep, file, this.entry());
-  }
+  }, this);
 
   // resolve dependencies from entry files,
   // and remove unresolved deps
@@ -649,7 +648,7 @@ Duo.prototype.dependencies = function *(file, map) {
   map[file.id] = file.json();
 
   // recurse the dependency's dependencies
-  var gens = this.recurse(paths, map);
+  gens = this.recurse(paths, map);
   yield this.parallel(gens);
   return map;
 };
@@ -718,7 +717,7 @@ Duo.prototype.dependency = function *(dep, file, entry) {
 
   // ignore http dependencies
   if (http(dep)) {
-    debug('%s: ignoring dependency "%s"', file.id, dep)
+    debug('%s: ignoring dependency "%s"', file.id, dep);
     return false;
   }
 
@@ -783,12 +782,12 @@ Duo.prototype.dependency = function *(dep, file, entry) {
  */
 
 Duo.prototype.resolve = function *(dep, file, entry) {
-  var isManifest = this.manifest() == basename(dep);
+  var isManifest = this.manifest() === basename(dep);
   var ext = extension(dep) ? '' : '.' + entry.type;
   var path = resolve(dirname(file.path), dep);
-  var isRelative = './' == dep.slice(0, 2);
-  var isParent = '..' == dep.slice(0, 2);
-  var isAbsolute = '/' == dep[0];
+  var isRelative = dep.slice(0, 2) === './';
+  var isParent = dep.slice(0, 2) === '..';
+  var isAbsolute = dep[0] === '/';
   var ret;
 
   if (isManifest) {
@@ -830,7 +829,7 @@ Duo.prototype.resolve = function *(dep, file, entry) {
 
   // check filesystem for relative asset
   function *isRelativeCSS(entry, path) {
-    if ('css' != entry.type) return false;
+    if (entry.type !== 'css') return false;
     path = stripPath(path);
     if (!extension(path)) return false;
     return yield exists(path);
@@ -884,7 +883,7 @@ Duo.prototype.package = function (dep, file) {
   var token = this.token();
 
   // initialize the package
-  var pkg = Package(gh.package, gh.ref);
+  var pkg = new Package(gh.package, gh.ref);
   pkg.directory(this.installPath());
   if (token) pkg.token(token);
 
@@ -957,7 +956,7 @@ Duo.prototype.findDependency = function(dep, manifest) {
   var rext = /([\.][a-z]+)?/;
 
   // Include development dependencies if `development(true)` is set.
-  if (dev && manifest == this.json) {
+  if (dev && manifest === this.json) {
     deps = extend(deps, manifest.development || {});
   }
 
@@ -969,8 +968,8 @@ Duo.prototype.findDependency = function(dep, manifest) {
 
   // Not enough information yet.
   // Search through the manifest for our dependency.
-  for (var dep in deps) {
-    if (re.test(dep) || dep.replace('/', '-') == gh.repo) {
+  for (dep in deps) {
+    if (re.test(dep) || dep.replace('/', '-') === gh.repo) {
       gh.package = dep;
       gh.ref = deps[dep];
       return gh;
@@ -1016,11 +1015,11 @@ Duo.prototype.findDependency = function(dep, manifest) {
 Duo.prototype.findRoot = function (path) {
   var root = this.root();
 
-  while (path != '.' && path != root && !isSlug(basename(path))) {
+  while (path !== '.' && path !== root && !isSlug(basename(path))) {
     path = dirname(path);
   }
 
-  if (path == '.') {
+  if (path === '.') {
     throw error('could not find root for %s', path);
   }
 
@@ -1051,7 +1050,7 @@ Duo.prototype.bundle = function *(path) {
   try {
     yield rm(dest);
   } catch(e) {
-    if ('ENOENT' != e.code) throw e;
+    if (e.code !== 'ENOENT') throw e;
   }
 
   // symlink or copy the file
@@ -1059,7 +1058,7 @@ Duo.prototype.bundle = function *(path) {
   try {
     yield action(path, dest);
   } catch(e) {
-    if ('EEXIST' != e.code) throw e;
+    if (e.code !== 'EEXIST') throw e;
     else debug('caught: %s already exists', dest);
   }
 
@@ -1119,7 +1118,7 @@ function extension(path) {
 
 function error(msg) {
   var args = slice.call(arguments, 1);
-  var msg = fmt.apply(fmt, [msg].concat(args));
+  msg = fmt.apply(fmt, [msg].concat(args));
   return new Error(msg);
 }
 
@@ -1158,8 +1157,8 @@ function stripPath(path) {
  */
 
 function http(url) {
-  return 'http' == url.slice(0, 4)
-    || '://' == url.slice(0, 3)
+  return url.slice(0, 4) === 'http'
+    || url.slice(0, 3) === '://'
     || false;
 }
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -3,14 +3,12 @@
  * Module dependencies.
  */
 
-var debug = require('debug')('duo-file');
 var clone = require('component-clone');
 var delegate = require('delegates');
 var filedeps = require('file-deps');
 var extend = require('extend.js');
 var exists = require('co-exists');
 var stat = require('fs').statSync;
-var thunk = require('thunkify');
 var mask = require('json-mask');
 var path = require('path');
 var relative = path.relative;
@@ -93,7 +91,8 @@ delegate(File.prototype, 'duo')
 File.prototype.dependencies = function () {
   if (this.deps) return this.deps;
   if (!this.src) return [];
-  return this.deps = filedeps(this.src, this.type);
+  this.deps = filedeps(this.src, this.type);
+  return this.deps;
 };
 
 /**

--- a/lib/mapping.js
+++ b/lib/mapping.js
@@ -4,8 +4,6 @@
  */
 
 var atomic = require('atomic-json');
-var extend = require('extend.js');
-var thunk = require('thunkify');
 var fs = require('co-fs');
 
 /**

--- a/lib/util.js
+++ b/lib/util.js
@@ -111,8 +111,8 @@ exports.type = function (src) {
 exports.plugins = function (root, plugins) {
   return plugins.map(function (plugin) {
     var local = resolve(root, plugin);
-    var npm = resolve(root, "node_modules", plugin);
-    var cwd = resolve(process.cwd(), "node_modules", plugin);
+    var npm = resolve(root, 'node_modules', plugin);
+    var cwd = resolve(process.cwd(), 'node_modules', plugin);
     var mod;
 
     if (exists(local)) mod = require(local);

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "co-mocha": "~1.0.3",
     "coffee-script": "~1.7.1",
     "duo-jade": "0.x",
+    "eslint": "^0.23.0",
     "expect.js": "^0.3.1",
     "gnode": "^0.1.1",
     "gulp": "~3.8.7",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,9 @@
+{
+  "env": {
+    "mocha": true
+  },
+  "rules": {
+    "new-cap": 0,
+    "no-use-before-define": 0
+  }
+}

--- a/test/cli.js
+++ b/test/cli.js
@@ -8,10 +8,8 @@ var readdir = require('fs').readdirSync;
 var extname = require('path').extname;
 var resolve = require('path').resolve;
 var exist = require('fs').existsSync;
-var Package = require('duo-package');
 var proc = require('child_process');
 var rmrf = require('rimraf').sync;
-var tmp = require('os').tmpdir();
 var assert = require('assert');
 var semver = require('semver');
 var fs = require('co-fs');
@@ -66,8 +64,8 @@ describe('Duo CLI', function () {
       var defs = [];
       var define = defs.push.bind(defs);
       define.amd = true;
-      var ctx = evaluate(out.stdout, { define: define });
-      assert('cli-duo' == defs[0]());
+      evaluate(out.stdout, { define: define });
+      assert.equal(defs[0](), 'cli-duo');
     });
 
     it('should support umd (commonjs)', function*(){
@@ -76,15 +74,15 @@ describe('Duo CLI', function () {
       var mod = { exports: {} };
       mod.module = mod;
       var ctx = evaluate(out.stdout, mod);
-      assert('cli-duo' == ctx.exports);
+      assert.equal(ctx.exports, 'cli-duo');
     });
 
     it('should support umd (global)', function*(){
       var out = yield exec('--standalone my-module --stdout index.js', 'cli-duo');
       if (out.error) throw out.error;
       var global = {};
-      var ctx = evaluate(out.stdout, global);
-      assert('cli-duo' == global['my-module']);
+      evaluate(out.stdout, global);
+      assert.equal(global['my-module'], 'cli-duo');
     });
   });
 
@@ -95,7 +93,7 @@ describe('Duo CLI', function () {
       var entry = yield fs.readFile(path('simple/build/index.js'), 'utf8');
       var map = convert.fromSource(entry).toObject();
       var src = map.sourcesContent[map.sources.indexOf('/two.js')];
-      assert(src.trim() == 'module.exports = \'two\';');
+      assert.equal(src.trim(), 'module.exports = \'two\';');
     });
   });
 
@@ -106,7 +104,7 @@ describe('Duo CLI', function () {
       var entry = yield fs.readFile(path('simple/build/index.js'), 'utf8');
       var map = convert.fromMapFileSource(entry, path('simple/build')).toObject();
       var src = map.sourcesContent[map.sources.indexOf('/two.js')];
-      assert(src.trim() == 'module.exports = \'two\';');
+      assert.equal(src.trim(), 'module.exports = \'two\';');
     });
 
     it('should behave the same way with `--development` on', function *() {
@@ -115,7 +113,7 @@ describe('Duo CLI', function () {
       var entry = yield fs.readFile(path('simple/build/index.js'), 'utf8');
       var map = convert.fromMapFileSource(entry, path('simple/build')).toObject();
       var src = map.sourcesContent[map.sources.indexOf('/two.js')];
-      assert(src.trim() == 'module.exports = \'two\';');
+      assert.equal(src.trim(), 'module.exports = \'two\';');
     });
 
     it('should log that the map was written', function *() {
@@ -130,10 +128,10 @@ describe('Duo CLI', function () {
     it('should build multiple entries to duo.assets()', function *() {
       var out = yield exec('*.js', 'entries');
       if (out.error) throw out.error;
-      var admin = yield build('entries/build/admin.js')
-      var index = yield build('entries/build/index.js')
-      assert('admin' == admin.main);
-      assert('index' == index.main);
+      var admin = yield build('entries/build/admin.js');
+      var index = yield build('entries/build/index.js');
+      assert.equal('admin', admin.main);
+      assert.equal('index', index.main);
       assert(contains(out.stderr, 'building : admin.js'));
       assert(contains(out.stderr, 'built : admin.js'));
       assert(contains(out.stderr, 'wrote : admin.js'));
@@ -159,11 +157,11 @@ describe('Duo CLI', function () {
 
     it('should work with options', function *() {
       var out = yield exec('-t js *.js', 'entries');
-      var admin = yield build('entries/build/admin.js')
-      var index = yield build('entries/build/index.js')
+      var admin = yield build('entries/build/admin.js');
+      var index = yield build('entries/build/index.js');
       if (out.error) throw out.error;
-      assert('admin' == admin.main);
-      assert('index' == index.main);
+      assert.equal('admin', admin.main);
+      assert.equal('index', index.main);
       assert(contains(out.stderr, 'building : admin.js'));
       assert(contains(out.stderr, 'built : admin.js'));
       assert(contains(out.stderr, 'wrote : admin.js'));
@@ -175,11 +173,11 @@ describe('Duo CLI', function () {
 
     it('should ignore unexpanded globs', function *() {
       var out = yield exec('*.js *.css', 'entries');
-      var admin = yield build('entries/build/admin.js')
-      var index = yield build('entries/build/index.js')
+      var admin = yield build('entries/build/admin.js');
+      var index = yield build('entries/build/index.js');
       if (out.error) throw out.error;
-      assert('admin' == admin.main);
-      assert('index' == index.main);
+      assert.equal('admin', admin.main);
+      assert.equal('index', index.main);
       assert(contains(out.stderr, 'building : admin.js'));
       assert(contains(out.stderr, 'built : admin.js'));
       assert(contains(out.stderr, 'wrote : admin.js'));
@@ -224,7 +222,7 @@ describe('Duo CLI', function () {
       assert(out.stdout);
       assert(out.stderr);
       ctx = evaluate(out.stdout);
-      assert('cli-duo' == ctx.main);
+      assert.equal(ctx.main, 'cli-duo');
     });
 
     it('should write to stdout with css', function *() {
@@ -247,8 +245,8 @@ describe('Duo CLI', function () {
         assert(out.stdout);
         assert(out.stderr);
         ctx = evaluate(out.stdout);
-        assert('cli-duo' == ctx.main);
-        assert(~ out.stdout.indexOf('//# sourceMappingURL=data:application/json;'));
+        assert.equal(ctx.main, 'cli-duo');
+        assert(out.stdout.indexOf('//# sourceMappingURL=data:application/json;') > -1);
       });
     });
 
@@ -259,8 +257,8 @@ describe('Duo CLI', function () {
         assert(out.stdout);
         assert(out.stderr);
         ctx = evaluate(out.stdout);
-        assert('cli-duo' == ctx.main);
-        assert(~ out.stdout.indexOf('//# sourceMappingURL=data:application/json;'));
+        assert.equal(ctx.main, 'cli-duo');
+        assert(out.stdout.indexOf('//# sourceMappingURL=data:application/json;') > -1);
       });
     });
   });
@@ -270,7 +268,7 @@ describe('Duo CLI', function () {
       out = yield exec('--quiet index.js', 'cli-duo');
       if (out.error) throw out.error;
       ctx = yield build('cli-duo/build/index.js');
-      assert('cli-duo' == ctx.main);
+      assert.equal(ctx.main, 'cli-duo');
       assert(!out.stderr);
       assert(!out.stdout);
       rm('cli-duo/build');
@@ -280,7 +278,7 @@ describe('Duo CLI', function () {
       out = yield exec('--stdout --quiet index.js > build.js', 'cli-duo');
       if (out.error) throw out.error;
       ctx = yield build('cli-duo');
-      assert('cli-duo' == ctx.main);
+      assert.equal(ctx.main, 'cli-duo');
       assert(!out.stderr);
       assert(!out.stdout);
       rm('cli-duo/build.js');
@@ -302,8 +300,7 @@ describe('Duo CLI', function () {
     describe('with --use', function () {
       it('should not log "using : <plugin>"', function *() {
         var out = yield exec('--quiet --use plugin.js index.js > build.js', 'cli-duo');
-        assert('' == out.stdout);
-        assert('' == out.stderr.trim());
+        assert.equal(out.stdout, '');
         rm('cli-duo/build.js');
       });
     });
@@ -372,7 +369,7 @@ describe('Duo CLI', function () {
 
   describe('duo --output <dir>', function () {
     it('should change to another output directory', function *() {
-      var out = yield exec('--output out *.js', 'entries');
+      yield exec('--output out *.js', 'entries');
       assert(exists('entries/out/index.js'));
       assert(exists('entries/out/admin.js'));
       rm('entries/out');
@@ -383,7 +380,7 @@ describe('Duo CLI', function () {
     it('should output to stdout', function *() {
       var out = yield exec('--stdout index.js', 'entries');
       var index = evaluate(out.stdout);
-      assert('index' == index.main);
+      assert.equal(index.main, 'index');
     });
 
     it('should error when multiple entries are passed', function *() {
@@ -399,8 +396,8 @@ describe('Duo CLI', function () {
         assert(out.stdout);
         assert(out.stderr);
         ctx = evaluate(out.stdout);
-        assert('cli-duo' == ctx.main);
-        assert(~ out.stdout.indexOf('//# sourceMappingURL=data:application/json;'));
+        assert.equal(ctx.main, 'cli-duo');
+        assert(out.stdout.indexOf('//# sourceMappingURL=data:application/json;') > -1);
       });
     });
 
@@ -411,8 +408,8 @@ describe('Duo CLI', function () {
         assert(out.stdout);
         assert(out.stderr);
         ctx = evaluate(out.stdout);
-        assert('cli-duo' == ctx.main);
-        assert(~ out.stdout.indexOf('//# sourceMappingURL=data:application/json;'));
+        assert.equal(ctx.main, 'cli-duo');
+        assert(out.stdout.indexOf('//# sourceMappingURL=data:application/json;') > -1);
       });
     });
   });
@@ -520,15 +517,15 @@ describe('Duo CLI', function () {
     });
 
     it('should exit with a non-zero code', function () {
-      assert(0 != res.code);
+      assert(res.code !== 0);
     });
 
     it('should write to stderr', function () {
-      assert('' != res.stderr);
+      assert(res.stderr !== '');
     });
 
     it('should not write to stdout', function () {
-      assert('' == res.stdout);
+      assert(res.stdout === '');
     });
   });
 });
@@ -578,7 +575,7 @@ function cleanup() {
   var dir = resolve(__dirname, 'fixtures');
   var dirs = readdir(dir);
   dirs.forEach(function(name){
-    if ('.' == name[0]) return;
+    if (name[0] === '.') return;
     var components = resolve(dir, name, 'components');
     var build = resolve(dir, name, 'build');
     rmrf(components);
@@ -604,7 +601,7 @@ function exists(file) {
  */
 
 function evaluate(js, ctx) {
-  var ctx = ctx || { window: {}, document: {} };
+  if (!ctx) ctx = { window: {}, document: {} };
   js = convert.removeComments(js);
   vm.runInNewContext('main =' + js + '(1)', ctx, 'main.vm');
   vm.runInNewContext('require =' + js + '', ctx, 'require.vm');
@@ -668,5 +665,5 @@ function execute(cmd, opts) {
 function contains(haystack, needle) {
   var rcolors = /\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]/g;
   haystack = haystack.replace(rcolors, '');
-  return !! ~haystack.indexOf(needle);
+  return haystack.indexOf(needle) > -1;
 }

--- a/test/examples.js
+++ b/test/examples.js
@@ -20,7 +20,7 @@ var dir = join(__dirname, '..', 'examples');
 
 var map = {
   css: 'build/build.css',
-  default: 'build.js',
+  default: 'build.js'
 };
 
 /**
@@ -28,7 +28,7 @@ var map = {
  */
 
 describe('Duo Examples', function () {
-  this.slow('2s')
+  this.slow('2s');
   this.timeout('10s');
 
   ls(dir).forEach(function (example) {
@@ -41,7 +41,7 @@ describe('Duo Examples', function () {
       var proc = spawn('node', args);
       var build = join(root, map[example] || map.default);
       proc.on('close', function (code) {
-        assert(0 == code);
+        assert.equal(code, 0);
         assert(exists(build));
         done();
       });


### PR DESCRIPTION
This adds ESLint to our build process, not required by any means, but there for devs to use and fix issues with.

The config is totally open to changes, I've tried to respect the original code style here and just enforce some consistency. The *primary* goal here is to include things like `no-unused-vars` to try and weed out unnecessary requires and optimize things generally.