### PR TITLE
Removing statSync call from File#modified()

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,7 @@
     "consistent-return": 0,
     "curly": [ 2, "multi-line" ],
     "no-shadow": 0,
+    "no-sync": 2,
     "no-underscore-dangle": 0,
     "no-use-before-define": [ 2, "nofunc" ],
     "strict": 0,

--- a/lib/duo.js
+++ b/lib/duo.js
@@ -565,6 +565,8 @@ Duo.prototype.run = unyield(function *() {
  */
 
 Duo.prototype.dependencies = function *(file, map) {
+  yield file.modified();
+
   map = map || {};
 
   var json = clone(this.mapping[file.id] || {});
@@ -714,7 +716,6 @@ Duo.prototype.recurse = function (deps, map) {
  */
 
 Duo.prototype.dependency = function *(dep, file, entry) {
-
   // ignore http dependencies
   if (http(dep)) {
     debug('%s: ignoring dependency "%s"', file.id, dep);

--- a/lib/file.js
+++ b/lib/file.js
@@ -8,7 +8,6 @@ var delegate = require('delegates');
 var filedeps = require('file-deps');
 var extend = require('extend.js');
 var exists = require('co-exists');
-var stat = require('fs').statSync;
 var mask = require('json-mask');
 var path = require('path');
 var relative = path.relative;
@@ -49,7 +48,6 @@ function File(attrs, duo) {
   this.attrs.path = resolve(attrs.root, path);
   this.attrs.type = attrs.type || extension(this.path);
   this.attrs.id = relative(duo.root(), this.path);
-  this.attrs.mtime = attrs.mtime || this.modified(this.path);
 
   // local vs remote
   this.attrs.local = !!(attrs.entry || attrs.local);
@@ -164,12 +162,16 @@ File.prototype.toString = function () {
  * @api private
  */
 
-File.prototype.modified = function (path) {
+File.prototype.modified = function *() {
   try {
-    return stat(path).mtime.getTime();
+    var stat = yield fs.stat(this.path);
+    this.attrs.mtime = stat.mtime.getTime();
   } catch (e) {
-    return (new Date()).getTime();
+    var now = new Date();
+    this.attrs.mtime = now.getTime();
   }
+
+  return this.mtime;
 };
 
 /**

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-sync */
 
 /**
  * Module dependencies.

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -4,6 +4,7 @@
   },
   "rules": {
     "new-cap": 0,
+    "no-sync": 0,
     "no-use-before-define": 0
   }
 }


### PR DESCRIPTION
When profiling duo to try and optimize it, it came up that the `statSync` call used by `File#modified()` was causing a slowdown. (sync methods block the event loop, so it was interfering with other async stuff indirectly by blocking the parallelism)

This is based on #472 since I used it to detect other usages of sync methods. To make it easier to see the exact change here, just view b9aa463.