### PR TITLE
Adding a public hash function to the API

### DIFF
--- a/lib/duo.js
+++ b/lib/duo.js
@@ -21,6 +21,7 @@ var rm = require('rimraf-then');
 var Pack = require('duo-pack');
 var main = require('duo-main');
 var mkdir = require('mkdirp');
+var hasha = require('hasha');
 var File = require('./file');
 var Ware = require('ware');
 var path = require('path');
@@ -1096,6 +1097,25 @@ Duo.prototype.forward = function (name) {
 
 Duo.prototype.parallel = function (arr) {
   return parallel(arr, this.concurrency());
+};
+
+/**
+ * Helper for hashing arbitrary input. (useful during caching,
+ * particularly for plugins)
+ *
+ * Objects will be serialized into a JSON string. Then the `input`
+ * string will be hashed using MD5.
+ *
+ * @param {Mixed} input
+ * @return {String} hash
+ */
+
+Duo.prototype.hash = function (input) {
+  if (typeof input !== 'string' && !Buffer.isBuffer(input)) {
+    input = JSON.stringify(input);
+  }
+
+  return hasha(input, { algorithm: 'md5' });
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "get-stdin": "^4.0.1",
     "glob": "^5.0.10",
     "has-generators": "^1.0.1",
+    "hasha": "^1.0.1",
     "json-mask": "^0.3.1",
     "language-classifier": "0.0.1",
     "mkdirp": "^0.5.0",

--- a/test/api.js
+++ b/test/api.js
@@ -270,6 +270,22 @@ describe('Duo API', function () {
     });
   });
 
+  describe('.hash(input)', function () {
+    var duo = Duo(__dirname);
+
+    it('should hash a string into md5', function () {
+      assert.equal(duo.hash('Hello World'), 'b10a8db164e0754105b7a99be72e3fe5');
+    });
+
+    it('should hash an object by serializing to JSON first', function () {
+      assert.equal(duo.hash({}), '99914b932bd37a50b983c5e7c90ae93b');
+    });
+
+    it('should allow Buffers too', function () {
+      assert.equal(duo.hash(new Buffer('abc')), '900150983cd24fb0d6963f7d28e17f72');
+    });
+  });
+
   describe('.cleanCache()', function () {
     it('should destroy the mapping file', function *() {
       var duo = build('simple-deps');


### PR DESCRIPTION
This adds a really basic helper function for generating quick hashes. The thinking here is that plugins can consume this to quickly generate cache keys. (in conjunction with #477 to give as much power to plugin authors as possible)

At first, I had duo calculating hashes on each file as it went, (as well as the results of duo-pack before running alternate plugins) but I didn't want to add any unnecessary overhead for people who aren't using plugins. (it's not much, but still decided better to restrain myself there)

I'm open to alternatives here, maybe since this is geared primarilly towards caching, it should be a part of `duo-cache` directly?