### PR TITLE
fix requiring files with dots in the name

### DIFF
--- a/lib/duo.js
+++ b/lib/duo.js
@@ -807,7 +807,8 @@ Duo.prototype.dependency = function *(dep, file, entry) {
 
 Duo.prototype.resolve = function *(dep, file, entry) {
   var isManifest = this.manifest() === basename(dep);
-  var ext = extension(dep) ? '' : '.' + entry.type;
+  var type = entry.type;
+  var ext = extension(dep) === type ? '' : '.' + type;
   var path = resolve(dirname(file.path), dep);
   var isRelative = dep.slice(0, 2) === './';
   var isParent = dep.slice(0, 2) === '..';
@@ -848,7 +849,8 @@ Duo.prototype.resolve = function *(dep, file, entry) {
   // ./file/index.{{ext}}
   return yield exists([
     ret + ext,
-    join(ret, 'index' + ext)
+    join(ret, 'index' + ext),
+    ret
   ]);
 
   // check filesystem for relative asset

--- a/test/api.js
+++ b/test/api.js
@@ -374,6 +374,12 @@ describe('Duo API', function () {
       assert.equal('index', ctx.main);
     });
 
+    it('should resolve dependencies that have dots in the name', function *() {
+      var js = yield build('file-dots', 'index.js').run();
+      var ctx = evaluate(js.code);
+      assert.strictEqual(ctx.a1, ctx.a2);
+    });
+
     it('should fetch and build direct dependencies', function *() {
       this.timeout(15000);
       var js = yield build('simple-deps').run();

--- a/test/fixtures/file-dots/a.1.js
+++ b/test/fixtures/file-dots/a.1.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/test/fixtures/file-dots/index.js
+++ b/test/fixtures/file-dots/index.js
@@ -1,0 +1,2 @@
+exports.a1 = require('./a.1');
+exports.a2 = require('./a.1.js');


### PR DESCRIPTION
This allows files that have dots in their name to be resolved properly. (fixes #483)

/cc @ndhoule 