### PR TITLE
Fixing empty entry source string

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -102,11 +102,12 @@ File.prototype.dependencies = function () {
  */
 
 File.prototype.load = function *() {
-  if (this.src) return this;
+  if (typeof this.src !== 'undefined') return this;
 
   // read the file
-  this.attrs.src = this.raw = this.raw
-    || (yield fs.readFile(this.path, 'utf8'));
+  var raw = this.raw;
+  if (typeof raw === 'undefined') raw = yield fs.readFile(this.path, 'utf8');
+  this.attrs.src = raw;
 
   // transform the file and update attributes
   var entry = this.entry ? this : this.duo.entry();
@@ -124,7 +125,7 @@ File.prototype.load = function *() {
  */
 
 File.prototype.exists = function *() {
-  if (this.raw) return true;
+  if (typeof this.raw !== 'undefined') return true;
   else return yield exists(this.path);
 };
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -106,7 +106,7 @@ File.prototype.load = function *() {
 
   // read the file
   var raw = this.raw;
-  if (typeof raw === 'undefined') raw = yield fs.readFile(this.path, 'utf8');
+  if (raw == null) raw = yield fs.readFile(this.path, 'utf8');
   this.attrs.src = raw;
 
   // transform the file and update attributes
@@ -125,7 +125,7 @@ File.prototype.load = function *() {
  */
 
 File.prototype.exists = function *() {
-  if (typeof this.raw !== 'undefined') return true;
+  if (this.raw == null) return true;
   else return yield exists(this.path);
 };
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -125,7 +125,7 @@ File.prototype.load = function *() {
  */
 
 File.prototype.exists = function *() {
-  if (this.raw == null) return true;
+  if (this.raw != null) return true;
   else return yield exists(this.path);
 };
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "coffee-script": "^1.9.3",
     "duo-jade": "0.x",
     "eslint": "^0.23.0",
-    "eslint-config-duo": "0.0.1",
+    "eslint-config-duo": "0.0.4",
     "expect.js": "^0.3.1",
     "gnode": "^0.1.1",
     "gulp": "^3.9.0",

--- a/test/api.js
+++ b/test/api.js
@@ -570,6 +570,10 @@ describe('Duo API', function () {
         assert.equal(ctx.b, 'b');
         assert.equal(ctx.c, 'c');
       });
+
+      it('should not fail when the input source code is empty', function *() {
+        yield Duo(path('simple')).entry('', 'css').run();
+      });
     });
 
     // describe('with .development(false)');


### PR DESCRIPTION
I've made the code checking `raw` and `src` a little more specific and clear. I believe I introduced this bug when I used ESLint to remove `== undefined` from these spots.

Basically, I've made the code a bit longer, but it should be a lot easier to maintain. (this fixes #484 and adds a test so it won't regress again)

/cc @darsain 