### PR TITLE
Properly respond to a modified manifest file

### DIFF
--- a/lib/duo.js
+++ b/lib/duo.js
@@ -1177,8 +1177,11 @@ Duo.prototype.isManifestModified = function *() {
   // if no previous value, assume yes
   var ret = !previous || previous !== value;
   debug('manifest modified? %j', ret);
-  delete require.cache[manifest]; // FIXME! this is an internal API
-  if (ret) this.json = readJson(manifest);
+  if (ret) {
+    // reset the manifest data internally if we determine it has been modified
+    delete require.cache[manifest]; // FIXME! this is an internal API
+    this.json = readJson(manifest);
+  }
   return ret;
 };
 

--- a/lib/duo.js
+++ b/lib/duo.js
@@ -500,7 +500,10 @@ Duo.prototype.install = unyield(function *() {
     .use(stoj());
 
   var cache = yield this.getCache();
-  if (cache) this.mapping = yield cache.read();
+  if (cache) {
+    this.mapping = yield cache.read();
+    this.jsonModified = yield this.isManifestModified();
+  }
 
   // ensure that the entry exists
   if (!(yield entry.exists())) {
@@ -616,7 +619,7 @@ Duo.prototype.dependencies = function *(file, map) {
   // check if the `file` has been modified
   // if not, skip parsing and recurse its
   // dependencies immediately.
-  if (cache && isCached) {
+  if (cache && !this.jsonModified && isCached) {
     debug('%s: has not been modified. skip parsing', file.id);
     map[file.id] = json;
     paths = values(json.deps);
@@ -1139,6 +1142,44 @@ Duo.prototype.hash = function (input) {
   }
 
   return hasha(input, { algorithm: 'md5' });
+};
+
+/**
+ * Check to see if the root manifest file has been modified.
+ *
+ * @return {Boolean}
+ */
+
+Duo.prototype.isManifestModified = function *() {
+  // the path to check
+  var manifest = this.path(this.manifest());
+
+  // check if we even have this manifest, bail if we don't
+  var exists = yield fs.exists(manifest);
+  if (!exists) return false;
+
+  // try to get cache, bail if not in use
+  var cache = yield this.getCache();
+  if (!cache) return false;
+
+  // stat the current manifest
+  var current = yield fs.stat(manifest);
+  var value = current.mtime.getTime();
+  debug('current mtime for manifest %d', value);
+
+  // retrieve what we've stored in the cache previously
+  // update the cache with our new value regardless
+  var key = [ 'manifest', 'modified' ];
+  var previous = yield cache.get(key);
+  if (previous) debug('previous mtime for manifest: %d', previous);
+  yield cache.put(key, value);
+
+  // if no previous value, assume yes
+  var ret = !previous || previous !== value;
+  debug('manifest modified? %j', ret);
+  delete require.cache[manifest]; // FIXME! this is an internal API
+  if (ret) this.json = readJson(manifest);
+  return ret;
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   "devDependencies": {
     "bluebird": "^2.9.20",
     "co-mocha": "~1.0.3",
+    "co-wait": "0.0.0",
     "coffee-script": "^1.9.3",
     "duo-jade": "0.x",
     "eslint": "^0.23.0",

--- a/test/fixtures/manifest-modify/component-a.json
+++ b/test/fixtures/manifest-modify/component-a.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "component/domify": "~0.2.0"
+  }
+}

--- a/test/fixtures/manifest-modify/component-b.json
+++ b/test/fixtures/manifest-modify/component-b.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "component/domify": "^1.4.0"
+  }
+}

--- a/test/fixtures/manifest-modify/index.js
+++ b/test/fixtures/manifest-modify/index.js
@@ -1,0 +1,1 @@
+require('domify');


### PR DESCRIPTION
Currently, if you change a version in your manifest file, it will only update the dependency when you:
 * clean the duo cache
 * remove `components`
 * touch/modify your files (and then, only the modified files get the updated version)

This causes headaches when using a manifest for managing versions in your project, because only the first 2 options end up being viable in practice. Not only that, but in a CI environment, you can't reliably cache the `components` directory, because it will not remain up-to-date for the same reasons.

This changes the internal behavior and makes a modified manifest invalidate the cache for individual files. (causing it to re-resolve the dependencies) A lot of the caching work I've been doing makes this a reliable action to take. (and will hit the API far fewer times than having to re-resolve _everything_ after destroying the cache)