### PR TITLE
Allow duo to always update dependencies

### DIFF
--- a/bin/_duo
+++ b/bin/_duo
@@ -33,6 +33,7 @@ var program = new Command('duo')
   .option('-r, --root <dir>', 'root directory to build from.', null)
   .option('-t, --type <type>', 'set the entry type', null)
   .option('-u, --use <plugin>', 'use transform plugin(s)', util.collect, [])
+  .option('-U, --update', 'always update dependencies', false)
   .option('-v, --verbose', 'show as much logs as possible', false)
   .option('-w, --watch', 'watch for changes and rebuild', false)
   .option('-s, --standalone <standalone>', 'outputs standalone javascript umd <standalone>', '')
@@ -293,6 +294,7 @@ function create(entry) {
     .sourceMap(sourceMap)
     .cache(program.cache)
     .copy(program.copy)
+    .update(program.update)
     .token(token)
     .entry(entry);
 

--- a/bin/duo-install
+++ b/bin/duo-install
@@ -25,6 +25,7 @@ program
   .option('-r, --root <dir>', 'root directory to build from.', null)
   .option('-t, --type <type>', 'set the entry type', null)
   .option('-u, --use <plugin>', 'use transform plugin(s)', util.collect, [])
+  .option('-U, --update', 'always update dependencies', false)
   .option('-v, --verbose', 'show as much logs as possible', false)
   .parse(process.argv);
 
@@ -184,6 +185,7 @@ function create(entry) {
   var duo = new Duo(root)
     .copy(program.copy)
     .cache(program.cache)
+    .update(program.update)
     .token(token)
     .entry(entry);
 

--- a/lib/duo.js
+++ b/lib/duo.js
@@ -70,6 +70,7 @@ function Duo(root) {
   this.development(false);
   this.sourceMap(false);
   this.concurrency(50);
+  this.update(false);
   this.cache(true);
 
   this.assets = [];
@@ -253,6 +254,21 @@ Duo.prototype.copy = function (value) {
 Duo.prototype.concurrency = function (value) {
   if (!arguments.length) return this._concurrency;
   this._concurrency = value;
+  return this;
+};
+
+/**
+ * Get or set the flag determining if we should always resolve dependencies.
+ * (rather than relying on cache)
+ *
+ * @param {Boolean} value (optional)
+ * @return {Duo|Boolean}
+ * @api public
+ */
+
+Duo.prototype.update = function (value) {
+  if (!arguments.length) return this._update;
+  this._update = value;
   return this;
 };
 
@@ -507,10 +523,9 @@ Duo.prototype.install = unyield(function* () {
     .use(stoj());
 
   var cache = yield this.getCache();
-  if (cache) {
-    this.mapping = yield cache.read();
-    this.jsonModified = yield this.isManifestModified();
-  }
+  if (cache) this.mapping = yield cache.read();
+
+  this.updateDeps = (yield this.isManifestModified()) || this.update();
 
   // ensure that the entry exists
   if (!(yield entry.exists())) {
@@ -626,7 +641,7 @@ Duo.prototype.dependencies = function* (file, map) {
   // check if the `file` has been modified
   // if not, skip parsing and recurse its
   // dependencies immediately.
-  if (cache && !this.jsonModified && isCached) {
+  if (cache && !this.updateDeps && isCached) {
     debug('%s: has not been modified. skip parsing', file.id);
     map[file.id] = json;
     paths = values(json.deps);

--- a/test/api.js
+++ b/test/api.js
@@ -211,7 +211,7 @@ describe('Duo API', function () {
   describe('.update()', function () {
     it('should get the update flag', function () {
       var duo = Duo(__dirname);
-      assert.equal(duo.update(), true);
+      assert.equal(duo.update(), false);
     });
   });
 

--- a/test/api.js
+++ b/test/api.js
@@ -208,6 +208,23 @@ describe('Duo API', function () {
     });
   });
 
+  describe('.update()', function () {
+    it('should get the update flag', function () {
+      var duo = Duo(__dirname);
+      assert.equal(duo.update(), true);
+    });
+  });
+
+  describe('.update(value)', function () {
+    it('should set the update flag', function () {
+      var duo = Duo(__dirname);
+      duo.update(true);
+      assert.equal(duo.update(), true);
+      duo.update(false);
+      assert.equal(duo.update(), false);
+    });
+  });
+
   describe('.cache()', function () {
     it('should get the cache flag', function () {
       var duo = Duo(__dirname);


### PR DESCRIPTION
This adds a `-U, --update` flag to the CLI (and a corresponding `.update([value])` method to the API) that forces duo to re-resolve all dependencies. (regardless of mtimes)

Since we are using conditional GETs in the Github API, checking for updates to the tags will _not_ count towards your API limit!

This is the last piece needed to safely cache the `components` directory in a CI environment, since now we can ensure that we get the latest version of our dependencies. Before, the only way to ensure this was by building `components/` from scratch _every_ time, which is terribly inefficient.

Unfortunately, I was unable to find a way to test such a thing, since it depends on a remote releasing a new version since the last time duo was ran, which we can't mock as of now. :(