### PR TITLE
caching a list of packages internally, to prevent duplicating work

### DIFF
--- a/lib/duo.js
+++ b/lib/duo.js
@@ -76,6 +76,7 @@ function Duo(root) {
   this.assets = [];
   this.mapping = {};
   this.includes = {};
+  this.packages = {};
   this.json = readJson(this.path('component.json'));
 
   // plugins
@@ -934,6 +935,10 @@ Duo.prototype.package = function (dep, file) {
   if (!gh) return null;
 
   var token = this.token();
+
+  // check if this package is already in flight
+  var slug = [ gh.package, gh.ref ].join('@');
+  if (slug in this.packages) return this.packages[slug];
 
   // initialize the package
   var pkg = new Package(gh.package, gh.ref);


### PR DESCRIPTION
It turns out that in complex projects, it's not hard to hit the API limit. I've discovered that packages are being resolved over and over again.

Since they are kicked off asynchronously, there's not an indication that the given package is already being resolved. (particularly if there are multiple pkg objects referencing the same package)

This changes it so that they same `pkg` object will be used in cases where the `slug` is identical. I'll also be adding changes to `duo-package` so that it also knows when the package is already in flight. (similar to how it checks before downloading)