### PR TITLE
fixed endless while loop in find-root function

### DIFF
--- a/lib/duo.js
+++ b/lib/duo.js
@@ -1073,7 +1073,7 @@ Duo.prototype.findDependency = function (dep, manifest) {
 Duo.prototype.findRoot = function (path) {
   var root = this.root();
 
-  while (path !== '.' && path !== root && !isSlug(basename(path))) {
+  while (path !== '.' && path !== '/' && path !== root && !isSlug(basename(path))) {
     path = dirname(path);
   }
 


### PR DESCRIPTION
Hey there again,

I have a (at the moment) private project which uses `roo`, `duo` and `duo-babel` so I can not 100% tell why I experience this issue and others not.

However what happens is that the `while` loop runs infinite as it converges to `/` I do not know why it does this (here are the var values):
- path: `/Users/bodokaiser/src/github.com/bodokaiser/iswmle/app/sidebar/index.js`
- root: `/Users/bodokaiser/src/github.com/bodokaiser/iswmle/lib/../`

To get a fix as quick as possible I just added a condition to the loop so it stops.

If somebody is interested in further investigation I can give them access to the repo for reproduction.