### PR TITLE
only build node 4 and 5, the others shouldn't be used anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.11"
-  - "0.12"
-  - "iojs"
+  - "4"
+  - "5"
 script: make lint test
 cache:
   directories:


### PR DESCRIPTION
this changes our travis config to only run the CI for node 4 and 5 (effectively ends support for node 0.10, 0.11, 0.12 and iojs)