### PR TITLE
Improve `box-sizing` reset

### DIFF
--- a/examples/css/lib/base/index.css
+++ b/examples/css/lib/base/index.css
@@ -1,6 +1,10 @@
-* {
-  box-sizing: border-box;
-}
+ html {
+   box-sizing: border-box;
+ }
+
+ *, *:before, *:after {
+   box-sizing: inherit;
+ }
 
 html, body {
   height: 100%;


### PR DESCRIPTION
There is a better way to reset `box-sizing` than basic `*` reset.

Source: https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/
